### PR TITLE
config: review moves to Grok Build grok-4.6 at xhigh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Coordinator: Orca
 | --- | --- | --- | --- |
 | `control` | Claude Code | `opus` | `high` |
 | `implement` | Grok Build | `grok-4.6` | `medium` |
-| `review` | Codex | `gpt-5.6-sol` | `medium` |
+| `review` | Grok Build | `grok-4.6` | `xhigh` |
 | `release` | Grok Build | `grok-4.6` | `medium` |
 <!-- dely:end -->
 
@@ -53,10 +53,13 @@ Load Orca's native skill to launch and supervise each worker TUI. Do not wrap a
 headless `claude -p`, `codex exec` or `grok --prompt-file` in a shell tab.
 
 Review is independent by role: a fresh session that does not implement or edit
-the candidate. This project adds no phase-implied sandbox. Codex review is pinned
-to `--dangerously-bypass-approvals-and-sandbox` so that choice is explicit rather
-than a hidden default. Native Internet access, closure gates, result writes and
-coordinator completion stay available. If the selected coordinator is unavailable,
+the candidate. This project adds no phase-implied sandbox. Grok review is pinned
+to `--always-approve` so that choice is explicit rather than a hidden default.
+`cc-safety-net` is inert on Grok, which discovers plugin hooks and dispatches none
+of them, so the reviewer has no mechanical guard against in-repository git
+destruction; that gap is accepted and bounded by every phase boundary committing.
+Native Internet access, closure gates, result writes and coordinator completion
+stay available. If the selected coordinator is unavailable,
 stop and ask the human before any headless fallback.
 
 `design` runs in the control session and is not dispatched.

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ as prose outside the block rather than treating them as a package default.
 There is no configuration file, because `AGENTS.md` is read by every harness
 here and already holds project facts.
 
-This repository's combination is Orca, interactive TUIs, and Codex review pinned
-to `--dangerously-bypass-approvals-and-sandbox`. Another project may choose none
+This repository's combination is Orca, interactive TUIs, and Grok Build review
+pinned to `--always-approve`. Another project may choose none
 of those values. The skill loads the selected coordinator's native skill; it does
 not ship a coordinator adapter.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -834,9 +834,30 @@ Consequences: review regains gate execution, ordinary Internet access, writable 
 and native coordinator completion. A reviewer is technically able to edit the candidate;
 doing so invalidates that review rather than opening an automatic repair path. A selected
 coordinator becoming unavailable now interrupts the human before visibility is discarded.
-This repository pins Codex review to `--dangerously-bypass-approvals-and-sandbox` in
-`AGENTS.md`, so the absence of a sandbox is an explicit invocation rather than a hidden
-default.
+This repository pins its review invocation explicitly in `AGENTS.md`, so the absence of a
+sandbox is an explicit invocation rather than a hidden default.
+
+**Amended 2026-08-21.** That pin was `--dangerously-bypass-approvals-and-sandbox` while
+review ran on Codex. The product owner moved review to Grok Build `grok-4.6` at `xhigh`,
+and the Codex flag does not exist there, so the pin is now `--always-approve`. The
+property is unchanged and only its spelling is per-harness: the reviewer runs unattended,
+under no phase-implied sandbox, and that is stated on the command line rather than
+inherited from a config default.
+
+Two consequences follow from the harness, not from the phase. `cc-safety-net` is inert on
+Grok, so the reviewer loses the guard it had on Codex; `findings.md` §12 and §25 already
+record why, and the in-repository git destruction gap was already accepted for Grok
+implement and release workers. And `implement`, `review` and `release` now all run on Grok
+Build, so review independence rests entirely on role discipline — a fresh session that
+does not implement or edit the candidate — with no incidental difference of tool behind
+it. Roles were already settled as a choice per phase rather than a property of a tool, so
+this is within that decision; it removes a backstop nobody had claimed.
+
+Not verified today: Grok accepts `xhigh` for `grok-4.6`. `findings.md` §20 and
+`harness-surface.md` both record it, but this session established that Grok validates
+effort only at dispatch, so the value could not be confirmed without paying for a model
+call. An invalid effort fails loudly with the valid set inline, so the first real review
+dispatch is the check.
 
 Non-goals: this does not standardise coordinator commands, add review hardening, prove
 every harness/coordinator pairing or change the four phases and their dispositions.


### PR DESCRIPTION
Routine. The product owner changed this repository's review pin from Codex
`gpt-5.6-sol` at `medium` to Grok Build `grok-4.6` at `xhigh`.

## The managed block was rewritten by the skill, not by hand

```diff
-| `review` | Codex | `gpt-5.6-sol` | `medium` |
+| `review` | Grok Build | `grok-4.6` | `xhigh` |
```

`dely:setup` made that edit on the existing-block path, and `git diff` on
`AGENTS.md` shows exactly that one line — nothing outside the markers moved. That
path had never been exercised: this repository's block was written by the plan
that introduced the feature, not by the skill.

## What the skill deliberately does not touch, reconciled by hand

Setup owns one managed block and nothing else, so three places still named Codex
and its bypass flag — a flag that does not exist on Grok.

- `AGENTS.md` prose outside the block: the pin is now `--always-approve`. The
  property is unchanged and only its spelling is per-harness — the reviewer runs
  unattended, under no phase-implied sandbox, stated on the command line rather
  than inherited from a config default.
- `README.md`: this repository's stated combination.
- `docs/decisions.md`: the settled decision that named Codex is **amended in
  place** rather than rewritten, keeping its original reasoning intact.

## Two consequences, from the harness rather than the phase

**`cc-safety-net` is inert on Grok**, which discovers plugin hooks and dispatches
none of them, so the reviewer loses the guard it had on Codex. The in-repository
git destruction gap was already accepted for Grok implement and release workers;
this extends it to review. It stays bounded because every phase boundary commits.

**`implement`, `review` and `release` now all run on Grok Build**, so review
independence rests entirely on role discipline — a fresh session that does not
implement or edit the candidate — with no incidental difference of tool behind it.
Roles were already settled as a choice per phase rather than a property of a tool,
so this is within that decision. It removes a backstop nobody had claimed.

## Not verified

That Grok accepts `xhigh` for `grok-4.6`. `findings.md` §20 and
`harness-surface.md` both record it, but this session established that Grok
validates effort only at dispatch — `grok --reasoning-effort bogus models` exits 0
without validating — so confirming it would cost a model call. An invalid effort
fails loudly with the valid set inline, so the first real review dispatch is the
check.

Three remaining mentions of the Codex flag are deliberately left: two describe
Codex's own capability or the full-bypass flag of all three harnesses, and two are
dated historical records that were accurate when written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
