### PR TITLE
docs: close the two deferred setup smokes

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1930,6 +1930,10 @@ could not offer. The `0.6.0` run that produced this defect is the control: it
 wrote `none` and said nothing. Results go to `docs/findings.md` by that later
 unit. Triggered after the plugin caches are refreshed.
 
+**Run 2026-08-22 on `0.9.0`; results in `findings.md` §34.** The non-interactive
+run created nothing and named both choices it could not offer, the coordinator and
+the `CLAUDE.md` import. This deferred item is closed.
+
 **Whether a real non-interactive run actually emits the report.** Every check
 in this unit is static and proves only that the skill document states the
 rule; it cannot prove an agent obeys it. The behavioural check is the
@@ -2109,6 +2113,12 @@ repository with an `AGENTS.md` managed block and no `CLAUDE.md`:
    make.
 
 Results go to `docs/findings.md` by that later unit.
+
+**Run 2026-08-22 on `0.9.0`; results in `findings.md` §34.** All three steps
+passed: the warn fires without an import, is absent with one, and still fires on a
+`CLAUDE.md` of unrelated prose; the interactive run presented the offer as a
+question and declining left the file absent; the non-interactive run created
+nothing. This deferred item is closed.
 
 **Whether setup actually makes the offer to a human.** Every check in this
 unit is static or fixture-driven and proves the document states the rule and


### PR DESCRIPTION
Routine, documentation only. Closes the `dely:setup` work.

Two `Deferred` blocks in `docs/decisions.md` still described their post-release
smoke as work to do, while `findings.md` §34 already records it as run on `0.9.0`.
A deferred item that has been satisfied but still reads as pending is the same
stale-record defect this repository has corrected several times this cycle — a
`pending` pull request column, a superseded model table, a `presumably` that had
never been measured.

- The `coordinator-not-offered` smoke: the non-interactive run created nothing and
  named both choices it could not offer.
- The `setup-offers-claude-import` smoke: all three steps passed — the warn fires
  without an import, is absent with one, still fires on a `CLAUDE.md` of unrelated
  prose; the interactive run presented the offer as a question and declining left
  the file absent; the non-interactive run created nothing.

Each block keeps its procedure rather than losing it, per this file's convention,
with one line naming when it ran and where the results live.

Nothing else in the repository changes. `git diff --check`, both disclosure greps
and `tests/managed-block-contract.sh` were run against the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
