### PR TITLE
fix: align journal path advertising and doctor counts with the writer

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A cross-harness delivery workflow for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "hooks", "evidence"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A cross-harness delivery workflow for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "hooks", "evidence"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,10 @@ bash tests/delivery-doctor-grok-hook.sh
 ```
 
 ```bash
+bash tests/journal-path-shape.sh
+```
+
+```bash
 bash tests/managed-block-contract.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -257,13 +257,11 @@ claude --plugin-dir /path/to/project-delivery-procedure -p 'Two things, nothing 
 Then:
 
 ```bash
-ls -la ~/.delivery-journal/                                   # PostToolUse fired?
-jq -r '.payload | keys[]' ~/.delivery-journal/*.raw.jsonl | sort -u
-jq '.payload.tool_response' ~/.delivery-journal/*.raw.jsonl   # exit code present?
+bin/delivery-evidence                      # newest session, every Bash call
 ```
 
-A journal file means `PostToolUse` fired. The session quoting the identifiers
-block means `SessionStart` fired and injection worked.
+A session in the reader output means `PostToolUse` fired. The session quoting
+the identifiers block means `SessionStart` fired and injection worked.
 
 Journal location overrides with `DELIVERY_JOURNAL_DIR`.
 

--- a/bin/delivery-doctor
+++ b/bin/delivery-doctor
@@ -335,8 +335,10 @@ fi
 
 journal_dir="${DELIVERY_JOURNAL_DIR:-$HOME/.delivery-journal}"
 if [ -d "$journal_dir" ]; then
-  count=$(find "$journal_dir" -maxdepth 1 -name '*.raw.jsonl' -type f 2>/dev/null | wc -l | tr -d '[:space:]')
-  ok "journal directory exists, ${count} session file(s)"
+  current=$(find "$journal_dir" -mindepth 1 -maxdepth 1 -type d ! -name unparsed 2>/dev/null | wc -l | tr -d '[:space:]')
+  legacy=$(find "$journal_dir" -maxdepth 1 -name '*.raw.jsonl' -type f 2>/dev/null | wc -l | tr -d '[:space:]')
+  count=$(( ${current:-0} + ${legacy:-0} ))
+  ok "journal directory exists, ${count} session(s)"
   if [ "${count:-0}" -eq 0 ]; then
     warn "no sessions recorded yet — run one turn with --plugin-dir to confirm capture"
   fi

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1239,6 +1239,11 @@ journal's shape:
 trigger for acting is this rename reaching closure, so the fix lands between plans in
 its own unit rather than under this one.
 
+**Run 2026-08-22; this deferred item is closed.** SessionStart advertises the
+per-session directory the writer creates; `delivery-doctor` counts that layout and
+the legacy `.raw.jsonl` files without calling every current target a session file;
+README installation verification reads the journal through `bin/delivery-evidence`.
+
 ### 2026-08-21 — Consumer identifiers are pseudonymous; the evidence itself stays whole
 
 #### Context

--- a/hooks/session-start-context.sh
+++ b/hooks/session-start-context.sh
@@ -43,7 +43,7 @@ fi
 
 journal_dir="${DELIVERY_JOURNAL_DIR:-$HOME/.delivery-journal}"
 if [ -n "$session_id" ]; then
-  journal_line="- This session's evidence journal: ${journal_dir}/${session_id}.raw.jsonl"
+  journal_line="- This session's evidence journal: ${journal_dir}/${session_id}"
 else
   journal_line="- This session's evidence journal: unresolved — quote gate output verbatim instead of citing a file"
 fi

--- a/tests/journal-path-shape.sh
+++ b/tests/journal-path-shape.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Focused check: SessionStart advertises the per-session directory the writer
+# creates, and delivery-doctor counts that layout as well as legacy .raw.jsonl.
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+writer="$root/hooks/post-tool-journal.sh"
+session_start="$root/hooks/session-start-context.sh"
+doctor="$root/bin/delivery-doctor"
+[ -f "$writer" ] || { printf '%s\n' "missing writer: $writer" >&2; exit 1; }
+[ -f "$session_start" ] || { printf '%s\n' "missing SessionStart hook: $session_start" >&2; exit 1; }
+[ -f "$doctor" ] || { printf '%s\n' "missing doctor: $doctor" >&2; exit 1; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' "jq not on PATH; SessionStart and the doctor cannot run" >&2
+  exit 1
+fi
+
+journal=$(mktemp -d "${TMPDIR:-/tmp}/journal-path-shape.XXXXXX")
+out=$(mktemp "${TMPDIR:-/tmp}/journal-path-shape-doctor.XXXXXX")
+cleanup() { rm -rf "$journal" "$out"; }
+trap cleanup EXIT
+
+failed=0
+fail() {
+  printf '%s\n' "$*" >&2
+  failed=1
+}
+
+current_session='current-fixture'
+legacy_session='legacy-fixture'
+
+# Real current-layout data from the writer, not a hand-made directory.
+printf '%s' "{\"session_id\":\"${current_session}\",\"tool_name\":\"Bash\"}" \
+  | DELIVERY_JOURNAL_DIR="$journal" bash "$writer"
+current_dir="${journal}/${current_session}"
+if ! find "$current_dir" -maxdepth 1 -name '*.json' -type f | grep -q .; then
+  printf '%s\n' "writer did not create a per-session event file under $current_dir" >&2
+  exit 1
+fi
+
+# Deliberately supported legacy layout.
+printf '%s\n' '{"observed_at":"2026-08-20T00:00:00Z","payload":{"session_id":"legacy-fixture"}}' \
+  > "${journal}/${legacy_session}.raw.jsonl"
+
+# Writer fallback directory; not a session.
+mkdir -p "${journal}/unparsed"
+printf '%s\n' '{"unparsed":true}' > "${journal}/unparsed/${legacy_session}.json"
+
+# --- SessionStart must advertise the directory the writer creates ----------
+
+start_json=$(printf '%s' "{\"session_id\":\"${current_session}\"}" \
+  | CLAUDE_PROJECT_DIR="$root" DELIVERY_JOURNAL_DIR="$journal" bash "$session_start")
+ctx=$(printf '%s' "$start_json" | jq -r '.hookSpecificOutput.additionalContext // empty')
+got_path=$(printf '%s\n' "$ctx" | sed -n 's/^- This session'\''s evidence journal: //p')
+
+if [ "$got_path" = "${current_dir}.raw.jsonl" ]; then
+  fail "SessionStart still advertises the legacy flat path ${current_dir}.raw.jsonl"
+elif [ "$got_path" != "$current_dir" ]; then
+  fail "SessionStart advertised ${got_path:-<empty>}, expected per-session directory $current_dir"
+fi
+
+# --- doctor must count current directories and legacy files ----------------
+# Combined fixture: one current directory, one legacy file, and unparsed/.
+# A doctor that still counts only *.raw.jsonl returns 1. A doctor that counts
+# every top-level directory returns 3. Both are wrong; expected is 2.
+
+DELIVERY_JOURNAL_DIR="$journal" bash "$doctor" "$root" >"$out" 2>&1 || true
+
+journal_line=$(grep -E 'journal directory exists' "$out" || true)
+if [ -z "$journal_line" ]; then
+  fail "doctor printed no journal-directory line"
+  cat "$out" >&2
+else
+  count=$(printf '%s' "$journal_line" | grep -oE '[0-9]+' | tail -n 1)
+  if [ "${count:-0}" != "2" ]; then
+    fail "doctor counted ${count:-?} session(s) with one current directory, one legacy file, and unparsed/; expected 2"
+    printf '%s\n' "$journal_line" >&2
+  fi
+  case "$journal_line" in
+    *'session file'*)
+      fail "doctor still calls every current target a session file: $journal_line"
+      ;;
+  esac
+fi
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+printf '%s\n' 'journal path shape: ok'

--- a/tests/managed-block-contract.sh
+++ b/tests/managed-block-contract.sh
@@ -4,7 +4,7 @@
 # has no CLAUDE.md importing AGENTS.md; the setup skill exists, states the
 # non-offerable-choice rule in its own section, and offers the
 # Claude Code import instead of refusing to write CLAUDE.md; both plugin
-# manifests share version 0.9.0. Does not require claude, codex, grok or orca.
+# manifests share version 0.9.1. Does not require claude, codex, grok or orca.
 set -u
 
 root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
@@ -393,8 +393,8 @@ if [ -z "$claude_ver" ] || [ -z "$codex_ver" ]; then
   fail "a plugin manifest is missing version"
 elif [ "$claude_ver" != "$codex_ver" ]; then
   fail "plugin manifest versions differ: claude=${claude_ver} codex=${codex_ver}"
-elif [ "$claude_ver" != "0.9.0" ]; then
-  fail "plugin manifest version is ${claude_ver}, expected 0.9.0"
+elif [ "$claude_ver" != "0.9.1" ]; then
+  fail "plugin manifest version is ${claude_ver}, expected 0.9.1"
 fi
 
 # --- doctor fixtures --------------------------------------------------------


### PR DESCRIPTION
Routine correction of the deferred journal-path defect. The writer already
creates `${DELIVERY_JOURNAL_DIR}/<session-id>/<event>.json`. SessionStart was
still advertising a `.raw.jsonl` file that does not exist, and `delivery-doctor`
counted only that legacy layout.

## What changed

- `hooks/session-start-context.sh` advertises the per-session directory the writer creates.
- `bin/delivery-doctor` counts current-layout directories and legacy `.raw.jsonl` files, and no longer calls every current target a session file.
- `tests/journal-path-shape.sh` creates real fixture data from the writer and fails if SessionStart still advertises the flat path or if the doctor still counts only legacy files.
- README installation verification uses `bin/delivery-evidence` instead of probing `*.raw.jsonl`.
- The deferred decision is marked run/closed, historical text kept.
- Plugin manifests move from 0.9.0 to 0.9.1 because a shipped hook changed. The managed-block contract pin follows that bump.

Do not merge until independent review.