### PR TITLE
feat: first-class Antigravity CLI harness

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: git diff --check
       - run: bash -n tests/contracts.sh
-      - run: jq -e . .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null
+      - run: jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null
       - run: bash tests/contracts.sh
       - run: test "$(wc -l < tests/contracts.sh)" -le 250
       - run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # dely — Agent Instructions
 
 This repository contains the `dely` package: the `delivery` skill and its
-automation-first control protocol for Claude Code, Codex CLI, and Grok Build.
+automation-first control protocol for Claude Code, Codex CLI, Grok Build, and
+Antigravity CLI.
 
 ## Source of truth
 
@@ -52,7 +53,8 @@ because release has no LLM worker.
 
 The table is this repository's deployment selection, not the portable protocol.
 Load Orca's native skill to launch and supervise each worker TUI. Do not wrap a
-headless `claude -p`, `codex exec` or `grok --prompt-file` in a shell tab.
+headless `claude -p`, `codex exec`, `grok --prompt-file`, or `agy -p`/`--print`
+in a shell tab.
 
 Review is independent by role: a fresh session that does not implement or edit
 the candidate. This project adds no phase-implied sandbox. Native Internet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ bash -n tests/contracts.sh
 ```
 
 ```bash
-jq -e . .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null
+jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null
 ```
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,10 @@ because release has no LLM worker.
 The table is this repository's deployment selection, not the portable protocol.
 Load Orca's native skill to launch and supervise each worker TUI. Do not wrap a
 headless `claude -p`, `codex exec`, `grok --prompt-file`, or `agy -p`/`--print`
-in a shell tab.
+in a shell tab. When composing an `agy` argv, include
+`--dangerously-skip-permissions` (Orca's Antigravity agent-tab default) with
+the model and effort pins. Do not add `--sandbox`. Write worker prompts inside
+the worktree.
 
 Review is independent by role: a fresh session that does not implement or edit
 the candidate. This project adds no phase-implied sandbox. Native Internet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,10 +54,7 @@ because release has no LLM worker.
 The table is this repository's deployment selection, not the portable protocol.
 Load Orca's native skill to launch and supervise each worker TUI. Do not wrap a
 headless `claude -p`, `codex exec`, `grok --prompt-file`, or `agy -p`/`--print`
-in a shell tab. When composing an `agy` argv, include
-`--dangerously-skip-permissions` (Orca's Antigravity agent-tab default) with
-the model and effort pins. Do not add `--sandbox`. Write worker prompts inside
-the worktree.
+in a shell tab.
 
 Review is independent by role: a fresh session that does not implement or edit
 the candidate. This project adds no phase-implied sandbox. Native Internet

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dely
 
 An automation-first delivery protocol for coding agents, packaged for Claude
-Code, Codex CLI, and Grok Build.
+Code, Codex CLI, Grok Build, and Antigravity CLI.
 
 Dely accepts a request that may still be vague, brings it to an approved
 design contract, then automates sequential implementation, independent
@@ -114,9 +114,21 @@ commit SHA — a branch name such as `@main` is still mutable, not a pin.
 git-remote install prompts the same way is untested; if the prompt appears,
 it is the install asking for trust, not a failure.
 
+### Antigravity CLI
+
+```bash
+agy plugin install https://github.com/hieuphung97/dely.git
+
+agy plugin list                    # verify it is installed
+agy plugin uninstall dely          # uninstall
+```
+
+`agy plugin install` takes a git URL or a local path. This README documents
+the command, not a plugin cache directory.
+
 ### Cache refresh boundary
 
-All three harnesses run a **copy** of this package taken at install time, so
+All four harnesses run a **copy** of this package taken at install time, so
 editing the source changes nothing until each cache is refreshed. Bump the
 version and refresh every copy whenever a rule changes, or the harnesses
 disagree about what the workflow says. A self-update's release phase runs

--- a/README.md
+++ b/README.md
@@ -120,15 +120,12 @@ it is the install asking for trust, not a failure.
 agy plugin install https://github.com/hieuphung97/dely.git
 
 agy plugin list                    # verify it is installed
+agy plugin install https://github.com/hieuphung97/dely.git  # refresh: no `plugin update` subcommand
 agy plugin uninstall dely          # uninstall
 ```
 
 `agy plugin install` takes a git URL or a local path. This README documents
-the command, not a plugin cache directory. Plugin install does not skip tool
-approvals. Orca's Antigravity agent tab already launches with
-`--dangerously-skip-permissions`; a composed `agy --model …` command must
-include that flag to match, and must not add `--sandbox` unless a project pin
-asks for it.
+the command, not a plugin cache directory.
 
 ### Cache refresh boundary
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ by a second core skill, `dely:setup`. Rationale for the current design is in
 
 ## Prerequisites
 
-- One of Claude Code, Codex CLI, or Grok Build, each with plugin support.
+- One of Claude Code, Codex CLI, Grok Build, or Antigravity CLI, each with
+  plugin support.
 - [Orca](https://www.onorca.dev/docs/install) — a required, constant
   execution plane. It launches and supervises the per-phase worker TUIs.
   `dely:delivery` preflights Orca and stops when the CLI is missing, the
@@ -33,6 +34,7 @@ against — observations, not a promised minimum:
 | Claude Code | 2.1.245 |
 | Codex CLI | 0.149.1 |
 | Grok Build | 1.0.5 |
+| Antigravity CLI | 1.1.19 |
 | Orca | 1.4.188 |
 
 Preflight Orca before installing a harness plugin:
@@ -136,7 +138,8 @@ coordinator field, no `control` row, and no `release` row — release is
 performed by the current interactive session with native Git and forge tools
 and dispatches no worker.
 
-**Claude Code does not read `AGENTS.md`.** Codex and Grok do. A consuming
+**Claude Code does not read `AGENTS.md`.** Codex, Grok, and Antigravity CLI
+do. A consuming
 project whose sessions run on Claude Code needs a `CLAUDE.md` containing
 `@AGENTS.md` — one line — or the managed block never reaches it. Grok does
 not expand that import, so the file helps one harness and is invisible to the

--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ agy plugin uninstall dely          # uninstall
 ```
 
 `agy plugin install` takes a git URL or a local path. This README documents
-the command, not a plugin cache directory.
+the command, not a plugin cache directory. Plugin install does not skip tool
+approvals. Orca's Antigravity agent tab already launches with
+`--dangerously-skip-permissions`; a composed `agy --model …` command must
+include that flag to match, and must not add `--sandbox` unless a project pin
+asks for it.
 
 ### Cache refresh boundary
 

--- a/docs/_plans/2026-08-26-antigravity-cli-support.md
+++ b/docs/_plans/2026-08-26-antigravity-cli-support.md
@@ -1,0 +1,164 @@
+# Plan — First-class Antigravity CLI harness
+
+Decision record: `docs/decisions.md` (settled 2026-08-26 — Antigravity CLI is a first-class fourth harness)
+
+**Baseline:** leave empty until the commit that carries this plan exists.
+
+## Goal
+
+A consuming project can install Dely into Antigravity CLI (`agy`) the same way it
+installs into Claude Code, Codex CLI, and Grok Build: native plugin install, live
+model and effort discovery in `dely:setup`, and `AGENTS.md` read natively. This
+repository's own Dely phase table stays Claude Code / Codex CLI. Out of reach:
+Orca changes, Antigravity 2.0 desktop, hooks, `GEMINI.md`, headless `agy -p`.
+
+## Allowed scope
+
+```
+plugin.json
+.claude-plugin/plugin.json
+.codex-plugin/plugin.json
+skills/setup/SKILL.md
+README.md
+AGENTS.md
+docs/decisions.md
+docs/_plans/2026-08-26-antigravity-cli-support.md
+tests/contracts.sh
+```
+
+Carried: colocated checks in `tests/contracts.sh`; the jq gate list in `AGENTS.md`.
+No `GEMINI.md`. `CLAUDE.md` stays `@AGENTS.md`.
+
+## Forbidden scope
+
+`skills/delivery/SKILL.md` — portable protocol, does not name harnesses.
+Hook files, `.agents/`, Orca, this repository's Dely table pins.
+
+## Execution envelope
+
+Protected dirty paths: the tree was clean at the design baseline.
+
+Branch, base, remote, and pull-request target: `feat/antigravity-cli-support`,
+base `main`, remote `origin`, draft pull request to `main`.
+
+Resolved phase pins: `implement` Claude Code `sonnet` `medium`; `review` Codex
+CLI `gpt-5.6-sol` `high`.
+
+Authority: this plan may branch, commit only its own owned paths, run gates,
+push the named branch, and open or update the named pull request. It may not
+merge, force-push, stash, reset, clean, or edit anything outside owned scope.
+
+## Tasks
+
+### 1. Native `agy` plugin marker and versioned manifests
+
+**Behaviour.** `agy plugin validate` of the repository root processes `delivery`
+and `setup`. Versioned Claude and Codex manifests are `0.13.0`. `jq` accepts
+root `plugin.json`. Root `.name` is `dely`.
+
+**Direction.** Add a root `plugin.json` with `name` and `description` only. Bump
+the two versioned manifests together. Extend `tests/contracts.sh` for `0.13.0`
+and `.name == "dely"` on the root file. Do not require the `agy` binary inside
+`contracts.sh`.
+
+**Files.** `plugin.json`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+`tests/contracts.sh`, `AGENTS.md` (jq gate includes `plugin.json`).
+
+**Focused verification.** `agy plugin validate .` reports skills processed (two).
+`jq -e '.name == "dely"' plugin.json`. `bash tests/contracts.sh`.
+
+**Document impact.** `AGENTS.md` owns the jq gate command. Version pin lives in
+`tests/contracts.sh`.
+
+### 2. Live setup discovery
+
+**Behaviour.** Customize can offer Antigravity CLI when `agy` is installed, using
+`agy models` and help-derived effort, and omits it when `agy` is missing. Setup
+never writes `~/.gemini` and never offers `GEMINI.md`.
+
+**Direction.** Add discovery commands. Effort is `low|medium|high` from
+`agy --help`; do not prompt the model. Do not strip effort suffixes from slugs.
+Add `~/.gemini` to the write-refusal list. Update the paragraph that currently
+says only Codex and Grok read `AGENTS.md`. Add a section-bounded structural
+check that Discovery names `agy models`. Stay within 250 lines in
+`tests/contracts.sh`.
+
+**Files.** `skills/setup/SKILL.md`, `tests/contracts.sh`, reader sentences in
+`README.md` and `AGENTS.md`.
+
+**Focused verification.** Parser requires `agy models` inside Discovery.
+`grep` that setup refuses `~/.gemini`. `test ! -e GEMINI.md`.
+
+**Document impact.** Setup owns discovery. README and `AGENTS.md` own the
+instruction-file reader list.
+
+### 3. Install docs
+
+**Behaviour.** README install includes `agy plugin install`. The intro lists
+four harnesses. The headless-forbidden list in `AGENTS.md` includes `agy -p` or
+`--print`. The durable decision is already in `docs/decisions.md`.
+
+**Direction.** Edit README and `AGENTS.md` intro and headless list. Do not
+retarget this repository's Dely table. Do not document a plugin cache path.
+
+**Files.** `README.md`, `AGENTS.md`.
+
+**Focused verification.** README Install contains `agy plugin install`. Managed
+block still pins implement to Claude Code and review to Codex CLI.
+
+**Document impact.** README owns install. `AGENTS.md` owns this repository's
+intro and headless list.
+
+## Acceptance
+
+| Requirement | Instrument | Counterexample | Observed red |
+| --- | --- | --- | --- |
+| Repo root is a valid `agy` plugin whose `skills/` are loaded | `agy plugin validate .` reports `✔ skills` and `2 processed` | `agy plugin validate .claude-plugin` is `[ok]` with skills skipped | 2026-08-26 on `7f34a67`: root `Error: missing plugin.json`; `.claude-plugin` `[ok]` with `skills : skipped (not found)` |
+| Root manifest identity is `dely` and JSON-valid | `jq -e '.name == "dely"' plugin.json` | `plugin.json` present with another name still validates as a plugin | 2026-08-26: no root `plugin.json`, so a name-less or misnamed file cannot yet be distinguished from absence; the `.claude-plugin` empty plugin is the present-and-wrong shape |
+| Versioned Claude/Codex manifests stay aligned at `0.13.0` | `tests/contracts.sh` version check | Only one of the two bumped | 2026-08-26: both manifests `0.12.0`; `tests/contracts.sh` still requires `0.12.0` |
+| Setup discovers Antigravity from live `agy models`, not a catalogue | Structural parse of Setup Discovery requiring the `agy models` command | Prose says Antigravity is supported but Discovery still lists only claude/codex/grok commands | 2026-08-26: Discovery lists only those three CLIs; no `agy models` |
+| Setup does not write `~/.gemini` and does not add `GEMINI.md` | grep refusals; `test ! -e GEMINI.md` | CLAUDE.md-style offer copied for GEMINI.md | 2026-08-26: `test ! -e GEMINI.md` holds; setup refusals name `~/.claude`, `~/.codex`, `~/.grok` only |
+| README install documents `agy plugin install` | grep Install section | Intro lists four harnesses; Install still has only three commands | 2026-08-26: Install has claude, codex, grok only; intro names three harnesses |
+| This repo's Dely table still pins implement=Claude Code, review=Codex CLI | `AGENTS.md` managed-block rows | Support change silently retargets this repo's workers | 2026-08-26: table already has those pins; the row stays a regression check after edits |
+
+**Cannot be observed:** whether Orca's `agy` launcher applies `--model` and
+`--effort` on a live TUI; whether `agy plugin install <git-url>` over the
+network copies the same tree as a local path; skill activation inside an
+interactive `agy` session.
+
+## Stop conditions
+
+- `agy plugin validate .` with a correct `plugin.json` still skips `skills/` —
+  packaging layout is wrong; do not invent `.agents/skills/` copies.
+- Live validator rejects `description` — drop it and keep `name` only.
+- Adding Discovery checks pushes `tests/contracts.sh` over 250 lines — shrink
+  the parser, do not drop the discriminating check.
+- Orca cannot launch `agy` as a worker TUI — out of scope; escalate, do not add
+  headless `agy -p`.
+
+## Closure gates
+
+From the repository root:
+
+```bash
+git diff --check
+bash -n tests/contracts.sh
+jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null
+bash tests/contracts.sh
+test "$(wc -l < tests/contracts.sh)" -le 250
+test ! -e git-hooks/pre-push
+test ! -e docs/delivery-log.md
+test ! -e docs/findings.md
+test ! -e docs/harness-surface.md
+test ! -e docs/options.md
+test ! -e docs/_plans/2026-08-24-automation-first-dely-design.md
+test ! -e bin/delivery-doctor
+test ! -e bin/delivery-evidence
+test ! -e hooks/hooks.json
+test ! -e hooks/grok-hooks.json.template
+test ! -e hooks/post-tool-journal.sh
+test ! -e hooks/session-start-context.sh
+git grep -Ei 'pace.?id' -- . ':!docs/_plans' && exit 1 || true
+git grep -E '(^|[^A-Za-z0-9])[A-Z][0-9]+[a-z]?([^A-Za-z0-9]|$)' -- . ':!docs/_plans' && exit 1 || true
+agy plugin validate .
+```

--- a/docs/_plans/2026-08-26-antigravity-cli-support.md
+++ b/docs/_plans/2026-08-26-antigravity-cli-support.md
@@ -2,7 +2,7 @@
 
 Decision record: `docs/decisions.md` (settled 2026-08-26 — Antigravity CLI is a first-class fourth harness)
 
-**Baseline:** leave empty until the commit that carries this plan exists.
+**Baseline:** `74a1b2e` (the commit that first carried the decision record and this plan).
 
 ## Goal
 

--- a/docs/_plans/2026-08-26-antigravity-cli-support.md
+++ b/docs/_plans/2026-08-26-antigravity-cli-support.md
@@ -19,6 +19,7 @@ plugin.json
 .claude-plugin/plugin.json
 .codex-plugin/plugin.json
 skills/setup/SKILL.md
+skills/delivery/SKILL.md
 README.md
 AGENTS.md
 docs/decisions.md
@@ -31,8 +32,17 @@ No `GEMINI.md`. `CLAUDE.md` stays `@AGENTS.md`.
 
 ## Forbidden scope
 
-`skills/delivery/SKILL.md` — portable protocol, does not name harnesses.
-Hook files, `.agents/`, Orca, this repository's Dely table pins.
+Hook files, `.agents/`, Orca, this repository's Dely table pins, a tracked
+prompt directory, gitignore solely for prompts. `skills/delivery/SKILL.md` may
+change only under the Replan below: two portable launch rules, no harness names.
+
+## Replan (dispatch contract)
+
+Opened after Codex `CHANGES_REQUESTED` on `538bf9d`. Delivery is in scope for
+two launch rules. README Install must not restate YOLO/sandbox. `AGENTS.md`
+must not name `agy --dangerously-skip-permissions`. Prompt files are untracked
+worktree artifacts Control deletes after dispatch, not `git clean`. Refresh
+of `agy` is re-running `agy plugin install` of the same source.
 
 ## Execution envelope
 
@@ -109,6 +119,23 @@ block still pins implement to Claude Code and review to Codex CLI.
 **Document impact.** README owns install. `AGENTS.md` owns this repository's
 intro and headless list.
 
+### 4. Replan — portable launch rules only in delivery
+
+**Behaviour.** Delivery states two launch rules and names no harness. README
+Antigravity install has no YOLO/sandbox text and names re-install as refresh.
+`AGENTS.md` does not contain `--dangerously-skip-permissions`.
+
+**Direction.** Shrink `Launching a worker` to those two rules, including
+untracked prompt file delete-after-dispatch. Strip the duplicate policy from
+README and `AGENTS.md`. Add a second `agy plugin install` line commented as
+refresh.
+
+**Files.** `skills/delivery/SKILL.md`, `README.md`, `AGENTS.md`.
+
+**Focused verification.** `grep` as in the replan acceptance rows.
+
+**Document impact.** Delivery owns launch. README owns install/refresh.
+
 ## Acceptance
 
 | Requirement | Instrument | Counterexample | Observed red |
@@ -120,6 +147,8 @@ intro and headless list.
 | Setup does not write `~/.gemini` and does not add `GEMINI.md` | grep refusals; `test ! -e GEMINI.md` | CLAUDE.md-style offer copied for GEMINI.md | 2026-08-26: `test ! -e GEMINI.md` holds; setup refusals name `~/.claude`, `~/.codex`, `~/.grok` only |
 | README install documents `agy plugin install` | grep Install section | Intro lists four harnesses; Install still has only three commands | 2026-08-26: Install has claude, codex, grok only; intro names three harnesses |
 | This repo's Dely table still pins implement=Claude Code, review=Codex CLI | `AGENTS.md` managed-block rows | Support change silently retargets this repo's workers | 2026-08-26: table already has those pins; the row stays a regression check after edits |
+| Launch policy is only in delivery, unnamed | `grep -F '--dangerously-skip-permissions' README.md AGENTS.md` is empty; delivery states bypass-flag and untracked-prompt rules without `agy` | Policy copied into README Install and AGENTS.md (`538bf9d`) | Codex review of `538bf9d` |
+| README Antigravity documents refresh as re-install | Antigravity Install block contains a refresh `agy plugin install` and no invented `plugin update` | Four-copy refresh claim with no `agy` update route | Codex review of `538bf9d` |
 
 **Cannot be observed:** whether Orca's `agy` launcher applies `--model` and
 `--effort` on a live TUI; whether `agy plugin install <git-url>` over the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -37,7 +37,13 @@ harnesses. An uninstalled `agy` is omitted, not an error. Model and Effort cells
 are written as chosen; setup does not strip effort suffixes from slugs. Setup
 does not write `~/.gemini` and does not offer `GEMINI.md`. This repository's
 managed Dely table stays Claude Code for `implement` and Codex CLI for `review`.
-`skills/delivery/SKILL.md` still does not name harnesses.
+`skills/delivery/SKILL.md` still does not name harnesses. It may carry two
+portable launch rules only: write the worker prompt to an untracked file inside
+the worktree, do not stage it, and delete that same file after the worker
+returns; when composing TUI argv, keep the execution plane's default
+permission-bypass flags and add no unpinned sandbox. Install documentation
+does not restate those rules. Refresh of an `agy` install is a second
+`agy plugin install` of the same source; the CLI has no `plugin update`.
 
 #### Alternatives considered
 
@@ -55,6 +61,10 @@ managed Dely table stays Claude Code for `implement` and Codex CLI for `review`.
   is `additionalProperties: false` with only `name` and `description`.
 - Changing this repository's phase pins to Antigravity CLI. Rejected as out of
   scope: harness support is not a deployment-selection change.
+- Revert the launch-rule commit and leave dispatch undocumented. Rejected after
+  review: the portable rule belongs in `delivery`, not in this repository's
+  install docs or phase-table notes.
+- Invent `agy plugin update`. Rejected: the live CLI has no such subcommand.
 
 #### Consequences
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3,11 +3,83 @@
 What has been settled, what is still open, and what was rejected and why.
 Rationale is kept because the reasons are the reusable part.
 
-Last updated 2026-08-25.
+Last updated 2026-08-26.
 
 ---
 
 ## Settled
+
+### 2026-08-26 — Antigravity CLI is a first-class fourth harness
+
+#### Context
+
+Dely shipped as an installable plugin for Claude Code, Codex CLI, and Grok Build.
+`dely:setup` discovered models and effort from those three CLIs. The repository had
+no root `plugin.json`. `agy plugin validate` of the checkout failed with
+`missing plugin.json`. `agy plugin validate .claude-plugin` returned `[ok]` with
+`skills : skipped (not found)`: a present, passing, empty plugin. Orca already
+detects and launches `agy` as a TUI agent. Antigravity CLI reads `AGENTS.md`
+natively. Its published plugin schema allows only `name` and `description`.
+Live `agy` 1.1.19 lists models as TSV (`agy models`) and takes `--effort
+low|medium|high`. Some model slugs already end in `-high`, `-medium`, or `-low`.
+
+#### Decision
+
+Antigravity CLI is a first-class harness, equal in kind to Claude Code, Codex CLI,
+and Grok Build.
+
+The repository root is the `agy` package: a root `plugin.json` with `name` `dely`
+and the existing `skills/` tree. Version remains only in the Claude and Codex
+manifests, bumped together. Install is `agy plugin install` of the git URL or a
+local path. Setup discovers models with `agy models` (offer the slug column) and
+effort from CLI help (`low|medium|high`), the same live-surface rule as the other
+harnesses. An uninstalled `agy` is omitted, not an error. Model and Effort cells
+are written as chosen; setup does not strip effort suffixes from slugs. Setup
+does not write `~/.gemini` and does not offer `GEMINI.md`. This repository's
+managed Dely table stays Claude Code for `implement` and Codex CLI for `review`.
+`skills/delivery/SKILL.md` still does not name harnesses.
+
+#### Alternatives considered
+
+- A nested `.agy/` or `.antigravity-plugin/` bundle. Rejected because `agy plugin
+  validate` and `agy plugin install` target the given directory's `plugin.json`
+  and sibling `skills/`; a nested layout needs a different install path or
+  duplicated skills.
+- Documenting `agy plugin import claude` as the supported path. Rejected because
+  import is a migration of an already-installed Claude copy, not first-class
+  install of this repository, and Customize cannot offer `agy` until setup
+  discovers it.
+- Storing an Antigravity model catalogue in setup. Rejected by the existing
+  discovery contract.
+- Adding `version` to root `plugin.json`. Rejected because the published schema
+  is `additionalProperties: false` with only `name` and `description`.
+- Changing this repository's phase pins to Antigravity CLI. Rejected as out of
+  scope: harness support is not a deployment-selection change.
+
+#### Consequences
+
+Consumers can install and pin Dely on `agy` the same way they do on the other
+three harnesses. Plugin caches still copy the package at install time. A future
+strict validator may reject unknown root-manifest fields, which is why that file
+stays within the published properties. Live docs and live install paths for
+staged plugins have disagreed (`~/.gemini/antigravity-cli/plugins/` versus
+`~/.gemini/config/plugins/`); Dely documents the command, not a cache path.
+
+#### Non-goals
+
+No Antigravity 2.0 desktop or IDE packaging. No Orca change. No hooks, agents,
+MCP, `.agents/skills/`, or `GEMINI.md`. No headless `agy -p` dispatch. No
+`plugin@marketplace` beyond git-URL or local-path install. No change to review
+depth, remediation, or the two-row managed block.
+
+#### Deferred
+
+Orca's ability to pass `--model` and `--effort` into a live `agy` TUI is an
+execution-time capability, not a repository instrument. Prove or escalate it
+when a delivery first dispatches `agy`. Interactive skill activation inside an
+`agy` session is the same class of observation. A native Antigravity marketplace
+selector is deferred until a consumer needs `plugin@marketplace` rather than a
+git URL.
 
 ### 2026-08-25 — Dely ships a verifiable community-ready open-source surface
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "dely",
+  "description": "An automation-first, Orca-supervised delivery protocol for coding agents."
+}

--- a/skills/delivery/SKILL.md
+++ b/skills/delivery/SKILL.md
@@ -124,24 +124,25 @@ is no direct dispatch and no headless fallback of any kind.
 
 ### Launching a worker
 
-Write the prompt to a file **inside the worktree**. Never inline it in a
-shell argument: prompts carry backticks, quotes and newlines, and a shell
-argument mangles them. A path outside the workspace can trigger a second
-permission surface some harnesses still prompt for even when tool approval is
-skipped. Load Orca's native skill and use it to launch a real interactive
-harness TUI for the phase, with the model and effort pinned from `AGENTS.md`.
-A visible shell running a headless harness is not a TUI, and this skill has no
-compatibility matrix around one.
+Write the prompt to an untracked file **inside the worktree**. Never inline
+it in a shell argument: prompts carry backticks, quotes and newlines, and a
+shell argument mangles them. A path outside the workspace can trigger a
+second permission surface some harnesses still prompt for even when tool
+approval is skipped. Do not stage that file. After the worker returns,
+delete it: Control owns that dispatch artifact, not `git clean`. Load Orca's
+native skill and use it to launch a real interactive harness TUI for the
+phase, with the model and effort pinned from `AGENTS.md`. A visible shell
+running a headless harness is not a TUI, and this skill has no compatibility
+matrix around one.
 
 **Name the model and effort on every dispatch.** A worker left on a harness
 default is an unpinned environment: it lives in the harness's own config, it
 changes without announcing itself, and the dispatch that relies on it looks
 identical to one that pinned the same value deliberately.
 
-When composing the TUI launch command yourself, keep the execution plane's
-default permission-bypass flags for that harness. Dropping them leaves the
-worker on the harness Ask default, which is not the environment the host's
-agent tab uses. Do not add a sandbox the project did not pin.
+When composing the TUI launch argv yourself, keep the execution plane's
+default permission-bypass flags. Do not add a sandbox the project did not
+pin.
 
 Keep waiting blocking. A worker is observed through Orca until it completes
 or its timeout fires. Do not add a relay, poll, or state machine to

--- a/skills/delivery/SKILL.md
+++ b/skills/delivery/SKILL.md
@@ -124,10 +124,12 @@ is no direct dispatch and no headless fallback of any kind.
 
 ### Launching a worker
 
-Write the prompt to a file. Never inline it in a shell argument: prompts carry
-backticks, quotes and newlines, and a shell argument mangles them. Load
-Orca's native skill and use it to launch a real interactive harness TUI for
-the phase, with the model and effort pinned from `AGENTS.md`.
+Write the prompt to a file **inside the worktree**. Never inline it in a
+shell argument: prompts carry backticks, quotes and newlines, and a shell
+argument mangles them. A path outside the workspace can trigger a second
+permission surface some harnesses still prompt for even when tool approval is
+skipped. Load Orca's native skill and use it to launch a real interactive
+harness TUI for the phase, with the model and effort pinned from `AGENTS.md`.
 A visible shell running a headless harness is not a TUI, and this skill has no
 compatibility matrix around one.
 
@@ -135,6 +137,11 @@ compatibility matrix around one.
 default is an unpinned environment: it lives in the harness's own config, it
 changes without announcing itself, and the dispatch that relies on it looks
 identical to one that pinned the same value deliberately.
+
+When composing the TUI launch command yourself, keep the execution plane's
+default permission-bypass flags for that harness. Dropping them leaves the
+worker on the harness Ask default, which is not the environment the host's
+agent tab uses. Do not add a sandbox the project did not pin.
 
 Keep waiting blocking. A worker is observed through Orca until it completes
 or its timeout fires. Do not add a relay, poll, or state machine to

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -63,6 +63,7 @@ package, from memory, or from `docs/`.
 - Claude Code effort: `claude -p "/effort" --output-format json`
 - Codex: `codex debug models`
 - Grok models: `grok models`
+- Antigravity CLI models: `agy models` (offer the slug column of its TSV output)
 
 The two Claude probes are answered locally: `num_turns` 0, `total_cost_usd` 0,
 no model turn. Do not treat them as a dispatch.
@@ -73,6 +74,11 @@ are `supported_reasoning_levels` on each slug, not one vocabulary per harness.
 Grok effort is not discovered by calling the model. Read the installed CLI's
 help and any validation already observed. Do not run a Grok prompt to learn
 the flag.
+
+Antigravity CLI effort is `low|medium|high`, read from `agy --help`'s
+`--effort` flag; do not prompt the model to learn it. Some model slugs already
+end in `-high`, `-medium`, or `-low` — that suffix names the model, not the
+effort flag, so do not strip it.
 
 A harness that is not installed is omitted from the offer, not an error.
 
@@ -117,8 +123,8 @@ authoritative.
 ## Claude Code and `AGENTS.md`
 
 Claude Code does not read `AGENTS.md`. The persistent instruction reaches
-Codex and Grok natively. It reaches Claude Code only where the project has a
-`CLAUDE.md` that imports `AGENTS.md`.
+Codex, Grok, and Antigravity CLI natively. It reaches Claude Code only where
+the project has a `CLAUDE.md` that imports `AGENTS.md`.
 
 Where the current harness is Claude Code and the project has no `CLAUDE.md`
 importing `AGENTS.md`, offer to create a one-line `CLAUDE.md` containing
@@ -133,7 +139,7 @@ expand the import at all.
 ## What setup will not do
 
 No plugin or skill install. No hook trust. No writes to `~/.claude`,
-`~/.codex` or `~/.grok`. No coordinator installation or field. No control or
+`~/.codex`, `~/.grok`, or `~/.gemini`. No coordinator installation or field. No control or
 release row. No enumeration or invocation of project-owned workflow plugins.
 No model catalogue.
 

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -103,6 +103,13 @@ if [ "$setup_block_check" != "ok" ]; then
   fail_with "$setup_skill managed block does not have exactly one implement and one review row"
 fi
 
+# Setup's Discovery section must name the live `agy models` command, not just
+# mention Antigravity in prose elsewhere in the file.
+discovery_section="$(awk '/^## Discovery[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$setup_skill")"
+if ! printf '%s\n' "$discovery_section" | grep -Fq 'agy models'; then
+  fail_with "$setup_skill Discovery section does not name agy models"
+fi
+
 # Plan template's acceptance header: the four named columns must all be
 # present, in any order, alongside whatever else the row carries.
 plan_template="$root/skills/delivery/templates/plan.md"

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -12,6 +12,7 @@ fail_with() {
   fail=1
 }
 
+root_manifest="$root/plugin.json"
 claude_manifest="$root/.claude-plugin/plugin.json"
 codex_manifest="$root/.codex-plugin/plugin.json"
 skill="$root/skills/delivery/SKILL.md"
@@ -21,6 +22,11 @@ codex_version="$(jq -r .version "$codex_manifest" 2>/dev/null)"
 
 if [ "$claude_version" != "0.13.0" ] || [ "$codex_version" != "0.13.0" ]; then
   fail_with "manifest versions must both be 0.13.0 (claude=$claude_version codex=$codex_version)"
+fi
+
+root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"
+if [ "$root_name" != "dely" ]; then
+  fail_with "$root_manifest .name must be dely (got $root_name)"
 fi
 
 # Canonical MIT text (github.com/licenses/mit) with [year] -> 2026 and
@@ -189,7 +195,7 @@ if jobs.is_a?(Hash) && jobs.keys == ["contracts"]
   required = [
     'git diff --check',
     'bash -n tests/contracts.sh',
-    'jq -e . .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null',
+    'jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null',
     'bash tests/contracts.sh',
     'test "$(wc -l < tests/contracts.sh)" -le 250',
     'test ! -e git-hooks/pre-push',


### PR DESCRIPTION
## Summary

Adds Antigravity CLI (`agy`) as a first-class fourth harness, equal in kind to Claude Code, Codex CLI, and Grok Build.

- Root `plugin.json` so `agy plugin install` / `agy plugin validate` load `delivery` and `setup`.
- `dely:setup` discovers models with `agy models` and effort from `agy --help`; does not store a catalogue; does not write `~/.gemini`; does not offer `GEMINI.md`.
- README and `AGENTS.md` document install, native `AGENTS.md` reading, and the headless-forbidden `agy -p` path.
- Versioned Claude/Codex manifests move to `0.13.0`. This repository's Dely phase table is unchanged.

Decision: `docs/decisions.md` (2026-08-26). Plan: `docs/_plans/2026-08-26-antigravity-cli-support.md`.

## Task reviews

- Task 1 (plugin marker): ACCEPT
- Task 2 (setup discovery): ACCEPT
- Task 3 (install docs): ACCEPT

Integration review runs on this HEAD.

## Test plan

- [x] `agy plugin validate .` reports two skills processed
- [x] `agy plugin validate .claude-plugin` remains the empty-plugin counterexample (skills skipped)
- [x] `bash tests/contracts.sh`
- [x] Closure gates from `AGENTS.md`