### PR TITLE
Add first-class Kiro CLI harness support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,6 +43,8 @@ body:
         - Claude Code
         - Codex CLI
         - Grok Build
+        - Antigravity CLI
+        - Kiro CLI
         - Other / not sure
     validations:
       required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # dely — Agent Instructions
 
 This repository contains the `dely` package: the `delivery` skill and its
-automation-first control protocol for Claude Code, Codex CLI, Grok Build, and
-Antigravity CLI.
+automation-first control protocol for Claude Code, Codex CLI, Grok Build,
+Antigravity CLI, and Kiro CLI.
 
 ## Source of truth
 
@@ -53,8 +53,8 @@ because release has no LLM worker.
 
 The table is this repository's deployment selection, not the portable protocol.
 Load Orca's native skill to launch and supervise each worker TUI. Do not wrap a
-headless `claude -p`, `codex exec`, `grok --prompt-file`, or `agy -p`/`--print`
-in a shell tab.
+headless `claude -p`, `codex exec`, `grok --prompt-file`, `agy -p`/`--print`, or
+`kiro-cli chat --no-interactive` in a shell tab.
 
 Review is independent by role: a fresh session that does not implement or edit
 the candidate. This project adds no phase-implied sandbox. Native Internet

--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ agy plugin uninstall dely          # uninstall
 `agy plugin install` takes a git URL or a local path. This README documents
 the command, not a plugin cache directory.
 
+### Kiro CLI
+
+```bash
+npx skills add hieuphung97/dely --agent kiro-cli --global --skill delivery --skill setup
+
+npx skills list --agent kiro-cli --global    # verify it is installed
+npx skills update --global                   # update
+npx skills remove --agent kiro-cli --global --skill delivery --skill setup  # uninstall
+```
+
+`npx skills add` installs the existing `delivery` and `setup` skills — no
+Kiro Power, no duplicated skill tree — through the open `npx skills`
+installer, targeting the `kiro-cli` agent (`--agent`) at global scope
+(`--global`). Kiro's default agent discovers global skills from
+`~/.kiro/skills/` automatically. Invoke them natively in a Kiro CLI session
+as `/delivery` and `/setup`.
+
 ### Cache refresh boundary
 
 All four harnesses run a **copy** of this package taken at install time, so

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dely
 
 An automation-first delivery protocol for coding agents, packaged for Claude
-Code, Codex CLI, Grok Build, and Antigravity CLI.
+Code, Codex CLI, Grok Build, Antigravity CLI, and Kiro CLI.
 
 Dely accepts a request that may still be vague, brings it to an approved
 design contract, then automates sequential implementation, independent
@@ -19,7 +19,7 @@ by a second core skill, `dely:setup`. Rationale for the current design is in
 ## Prerequisites
 
 - One of Claude Code, Codex CLI, Grok Build, or Antigravity CLI, each with
-  plugin support.
+  plugin support, or Kiro CLI with the `npx skills` installer.
 - [Orca](https://www.onorca.dev/docs/install) — a required, constant
   execution plane. It launches and supervises the per-phase worker TUIs.
   `dely:delivery` preflights Orca and stops when the CLI is missing, the
@@ -35,6 +35,7 @@ against — observations, not a promised minimum:
 | Codex CLI | 0.149.1 |
 | Grok Build | 1.0.5 |
 | Antigravity CLI | 1.1.19 |
+| Kiro CLI | 2.16.2 |
 | Orca | 1.4.188 |
 
 Preflight Orca before installing a harness plugin:
@@ -146,7 +147,7 @@ as `/delivery` and `/setup`.
 
 ### Cache refresh boundary
 
-All four harnesses run a **copy** of this package taken at install time, so
+All five harnesses run a **copy** of this package taken at install time, so
 editing the source changes nothing until each cache is refreshed. Bump the
 version and refresh every copy whenever a rule changes, or the harnesses
 disagree about what the workflow says. A self-update's release phase runs
@@ -168,8 +169,8 @@ coordinator field, no `control` row, and no `release` row — release is
 performed by the current interactive session with native Git and forge tools
 and dispatches no worker.
 
-**Claude Code does not read `AGENTS.md`.** Codex, Grok, and Antigravity CLI
-do. A consuming
+**Claude Code does not read `AGENTS.md`.** Codex, Grok, Antigravity CLI, and
+Kiro CLI do. A consuming
 project whose sessions run on Claude Code needs a `CLAUDE.md` containing
 `@AGENTS.md` — one line — or the managed block never reaches it. Grok does
 not expand that import, so the file helps one harness and is invisible to the

--- a/docs/_plans/2026-08-26-kiro-cli-support.md
+++ b/docs/_plans/2026-08-26-kiro-cli-support.md
@@ -3,7 +3,7 @@
 Decision record: `docs/decisions.md` (settled 2026-08-26 — Kiro CLI is a
 first-class fifth harness)
 
-**Baseline:**
+**Baseline:** `279f9f425022393cbd3faf2fab7b827fe4baf319`
 
 ## Goal
 

--- a/docs/_plans/2026-08-26-kiro-cli-support.md
+++ b/docs/_plans/2026-08-26-kiro-cli-support.md
@@ -1,0 +1,186 @@
+# Plan — First-class Kiro CLI harness
+
+Decision record: `docs/decisions.md` (settled 2026-08-26 — Kiro CLI is a
+first-class fifth harness)
+
+**Baseline:**
+
+## Goal
+
+A consuming project can install Dely's two existing skills for Kiro CLI, invoke
+them with Kiro's native skill commands, select Kiro from live setup discovery,
+and pin it for Orca-supervised implementation or review. Out of reach: Kiro
+Powers, custom agents, hooks, MCP, non-CLI Kiro surfaces, headless dispatch,
+Orca changes, and live user-profile mutation.
+
+## Allowed scope
+
+```
+AGENTS.md
+README.md
+.claude-plugin/plugin.json
+.codex-plugin/plugin.json
+.github/ISSUE_TEMPLATE/bug_report.yml
+docs/decisions.md
+docs/_plans/2026-08-26-kiro-cli-support.md
+skills/setup/SKILL.md
+tests/contracts.sh
+```
+
+`tests/contracts.sh` is the colocated registry test for the package and setup
+contracts and is listed explicitly. `README.md`, `AGENTS.md`,
+`docs/decisions.md`, and the bug form own the affected public, deployment,
+decision, and contribution surfaces. No other colocated test, registry, or
+owning document was found.
+
+## Forbidden scope
+
+`plugin.json` stays the checked Antigravity manifest. `.claude-plugin/marketplace.json`
+has no version and needs no change. `skills/delivery/SKILL.md` remains portable
+and harness-neutral. No `.kiro/`, `~/.kiro`, custom agent, Kiro Power, Orca
+source, hook, MCP, `CLAUDE.md`, or workflow file changes. Do not install Dely
+into the maintainer's live Kiro profile.
+
+## Execution envelope
+
+Protected dirty paths: none; the tree was clean at baseline
+`b79ea56aab734d0363557ed710bf4e8177b76e48`.
+
+Branch, base, remote, and pull-request target: `feat/kiro-cli-support`, based on
+`main` at `b79ea56aab734d0363557ed710bf4e8177b76e48`, pushes to `origin`, and opens a
+pull request into `main`.
+
+Resolved phase pins: `implement` runs Claude Code `sonnet` at `medium`; `review`
+runs Codex CLI `gpt-5.6-sol` at `high`. The project pins no phase sandbox.
+
+Authority: this plan may branch, commit only its owned paths, run focused checks
+and closure gates, push `feat/kiro-cli-support`, and open or update its pull
+request into `main`. It may not merge, force-push, stash, reset, clean, install
+skills into a live harness profile, or edit anything outside owned scope.
+
+## Tasks
+
+### 1. Native Kiro skill installation and release packaging
+
+**Behaviour.** README users can install, verify, update, remove, and invoke the
+two Dely skills in Kiro through `npx skills`; both versioned manifests are
+`0.14.0`.
+
+**Direction.** Add one Kiro CLI install section using global scope, explicit
+`kiro-cli`, and explicit `delivery` and `setup` skills. Name `/delivery` and
+`/setup`. Extend the existing version and README structural checks compactly;
+`tests/contracts.sh` must remain at most 250 lines. Do not change root
+`plugin.json` or introduce a Kiro package.
+
+**Files.** `README.md`, `.claude-plugin/plugin.json`,
+`.codex-plugin/plugin.json`, `tests/contracts.sh`.
+
+**Focused verification.** A section-bounded shell predicate rejects a Kiro
+section that says support exists but instructs manual copying; it accepts only
+the documented `npx skills` add/update/remove surface and native invocation.
+`bash tests/contracts.sh` rejects split or stale manifest versions.
+
+**Document impact.** README owns installation and cache-refresh guidance. The
+decision record owns why Kiro uses skills rather than a Power.
+
+### 2. Live Kiro setup discovery and interactive dispatch policy
+
+**Behaviour.** Customize offers installed Kiro CLI models from live JSON and
+effort from CLI help; unavailable or unusable Kiro discovery is omitted. Kiro
+receives pins through native `AGENTS.md`, and Dely forbids headless Kiro workers.
+
+**Direction.** Add the exact model command to Setup's Discovery section, offer
+`model_id`, read effort from help, and forbid writes to `~/.kiro` or custom
+agents. Update project support prose and the headless-forbidden list without
+changing this repository's phase pins. Extend the existing section-bounded
+discovery check rather than adding a parser abstraction.
+
+**Files.** `skills/setup/SKILL.md`, `AGENTS.md`, `tests/contracts.sh`.
+
+**Focused verification.** `kiro-cli chat --list-models --format json | jq -e
+'(.models | length > 0 and all(has("model_id"))) and (.default_model | type ==
+"string")'` succeeds on the live CLI. `kiro-cli chat --help` contains
+`--effort`. The structural test rejects Kiro prose backed by a stored catalogue
+or the wrong model field, and rejects a dispatch policy that omits the headless
+Kiro command.
+
+**Document impact.** `AGENTS.md` owns repository deployment policy;
+`skills/setup/SKILL.md` owns discovery and configuration boundaries.
+
+### 3. Five-harness onboarding and contribution surface
+
+**Behaviour.** The README consistently describes five supported harnesses and
+the bug form lets reporters choose each one, including both Antigravity CLI and
+Kiro CLI.
+
+**Direction.** Reconcile the introduction, prerequisites, checked versions,
+cache wording, setup context, and ordinary-use count. Add both missing harness
+options to the bug form. Extend the existing issue-form validation with the
+smallest check that rejects a list containing Kiro but omitting Antigravity.
+
+**Files.** `README.md`, `.github/ISSUE_TEMPLATE/bug_report.yml`,
+`tests/contracts.sh`.
+
+**Focused verification.** `bash tests/contracts.sh` rejects a present
+four-option bug form that includes Kiro but omits Antigravity, and accepts the
+five exact harness names. A README section check rejects a support claim without
+the Kiro install path.
+
+**Document impact.** README owns the supported-harness claim; the bug form owns
+the human harness vocabulary.
+
+## Acceptance
+
+| Requirement | Instrument | Counterexample | Observed red |
+| --- | --- | --- | --- |
+| Kiro has native install, update, removal, and `/delivery` invocation | Section-bounded README predicate plus `bash tests/contracts.sh` | A Kiro section says it is supported but tells users to copy the skills manually | 2026-08-26 in-memory probe: `wrong install rc=1`; correct shape `rc=0` |
+| Setup uses live Kiro model ids and help-derived effort | Setup Discovery structural check; live model JSON checked with `jq`; help checked for `--effort` | Kiro is present but setup uses a stored catalogue or offers `model_name` instead of `model_id` | 2026-08-26 probes: wrong Discovery `rc=1`, wrong model JSON `rc=1`; live discovery and effort surface `rc=0` |
+| Dely dispatches an interactive Kiro TUI only | AGENTS policy check names `kiro-cli chat --no-interactive` as forbidden headless dispatch | Kiro is listed as supported but a headless chat is allowed in a shell tab | 2026-08-26 in-memory probe: wrong dispatch policy `rc=1`; correct shape `rc=0` |
+| Human reports can identify all five harnesses | Issue-form option check requires the five exact harness names | The form adds Kiro but still omits Antigravity | 2026-08-26 in-memory probe: wrong options `rc=1`; correct shape `rc=0` |
+| Versioned manifests stay aligned at `0.14.0` | `bash tests/contracts.sh` reads both manifest versions | Only the Claude manifest is `0.14.0`; Codex remains `0.13.0` | 2026-08-26 in-memory predicate with split values: `rc=1` |
+
+**Cannot be observed:** actual global installation and skill activation without
+mutating `~/.kiro`; a custom agent that disables default skill resources; Orca
+passing a selected Kiro model and effort in a consumer project; future behaviour
+of the external `npx skills` installer. Local checks prove the checked command
+surface and package contract, not those profile- and runtime-bound effects.
+
+## Stop conditions
+
+- Kiro's live model result lacks usable `model_id` values or its help lacks
+  model or effort flags — do not store a fallback catalogue.
+- `npx skills` no longer supports Kiro global installs or cannot select both
+  existing skills — do not replace it with manual copies without replan.
+- Supporting Kiro requires changing root `plugin.json`, duplicating `skills/`,
+  editing `skills/delivery/SKILL.md`, changing Orca, or writing `~/.kiro` — return
+  `NEEDS_REPLAN`.
+- The focused contract cannot fit while preserving the 250-line test limit —
+  simplify the check or return `NEEDS_REPLAN`; do not remove an existing gate.
+- A task needs any path outside allowed scope, or an existing contract disproves
+  the design — stop rather than absorb the change.
+
+## Closure gates
+
+Run from `/Users/hieuphung/Projects/dely`:
+
+```bash
+git diff --check
+bash -n tests/contracts.sh
+jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null
+bash tests/contracts.sh
+test "$(wc -l < tests/contracts.sh)" -le 250
+test ! -e git-hooks/pre-push
+test ! -e docs/delivery-log.md
+test ! -e docs/findings.md
+test ! -e docs/harness-surface.md
+test ! -e docs/options.md
+test ! -e docs/_plans/2026-08-24-automation-first-dely-design.md
+test ! -e bin/delivery-doctor
+test ! -e bin/delivery-evidence
+test ! -e hooks/hooks.json
+test ! -e hooks/grok-hooks.json.template
+test ! -e hooks/post-tool-journal.sh
+test ! -e hooks/session-start-context.sh
+git grep -Ei 'pace.?id' -- . ':!docs/_plans' && exit 1 || true
+git grep -E '(^|[^A-Za-z0-9])[A-Z][0-9]+[a-z]?([^A-Za-z0-9]|$)' -- . ':!docs/_plans' && exit 1 || true
+```

--- a/docs/_plans/2026-08-26-kiro-cli-support.md
+++ b/docs/_plans/2026-08-26-kiro-cli-support.md
@@ -41,6 +41,26 @@ and harness-neutral. No `.kiro/`, `~/.kiro`, custom agent, Kiro Power, Orca
 source, hook, MCP, `CLAUDE.md`, or workflow file changes. Do not install Dely
 into the maintainer's live Kiro profile.
 
+## Replan (Kiro Discovery subsection)
+
+Opened after Task 2's scoped re-review did not accept `73be896`. Headless
+polarity is already an exact normalized sentence match in `AGENTS.md` and stays
+closed. The remaining finding is that Setup's stored-catalogue counterexample
+still passes: `tests/contracts.sh` exact-matches only the Kiro models bullet, so
+a contradictory "use stored catalogue" paragraph elsewhere in Discovery is
+invisible (`old=0`, `new=0`).
+
+Split one new task with a fresh implementer and a fresh reviewer. Create
+`### Kiro CLI` under Setup Discovery and match that whole subsection verbatim,
+so any contradictory paragraph in it is rejected. Do not change live-discovery
+behaviour, omit-if-unavailable, authority, package architecture, or owned
+scope. Do not start a second Task 2 repair loop. Task 3 waits until this new
+task accepts.
+
+The managed block in `AGENTS.md` is unchanged. Remaining reviews in this
+delivery use Claude Code `opus` at `high` (the live `/model` alias for Opus 5)
+instead of Codex CLI, per the 2026-08-26 Control-session override.
+
 ## Execution envelope
 
 Protected dirty paths: none; the tree was clean at baseline
@@ -50,8 +70,11 @@ Branch, base, remote, and pull-request target: `feat/kiro-cli-support`, based on
 `main` at `b79ea56aab734d0363557ed710bf4e8177b76e48`, pushes to `origin`, and opens a
 pull request into `main`.
 
-Resolved phase pins: `implement` runs Claude Code `sonnet` at `medium`; `review`
-runs Codex CLI `gpt-5.6-sol` at `high`. The project pins no phase sandbox.
+Resolved phase pins: `implement` runs Claude Code `sonnet` at `medium`. Task 1
+and Task 2 reviews used Codex CLI `gpt-5.6-sol` at `high`. Remaining reviews in
+this delivery (Task 2b, Task 3, and integration review) run Claude Code `opus`
+at `high`. The project pins no phase sandbox. This delivery does not rewrite
+the managed block.
 
 Authority: this plan may branch, commit only its owned paths, run focused checks
 and closure gates, push `feat/kiro-cli-support`, and open or update its pull
@@ -107,6 +130,31 @@ Kiro command.
 **Document impact.** `AGENTS.md` owns repository deployment policy;
 `skills/setup/SKILL.md` owns discovery and configuration boundaries.
 
+### 2b. Bound Setup's Kiro Discovery subsection
+
+**Behaviour.** Setup's Kiro live-discovery contract is the entire `### Kiro CLI`
+subsection under Discovery. A subsection that keeps the live command and
+`model_id` but tells setup to use a stored catalogue is rejected.
+
+**Direction.** Add `### Kiro CLI` under Setup Discovery. Move Kiro-specific
+model and effort discovery prose into that subsection. Match the whole
+subsection verbatim in `tests/contracts.sh`. Do not change live JSON discovery,
+`model_id`, help-derived effort, omit-if-unavailable, or the no-`~/.kiro` /
+no-custom-agent refusals. Do not edit `AGENTS.md`, README, manifests, or
+delivery. Keep `tests/contracts.sh` at most 250 lines; compact existing checks
+if needed, and do not drop a gate.
+
+**Files.** `skills/setup/SKILL.md`, `tests/contracts.sh`.
+
+**Focused verification.** Observe the Task 2 false pass first: on `73be896`, a
+Discovery section that keeps the current Kiro models bullet and adds a
+"use stored catalogue" paragraph must still exit 0. After the change, the same
+present-but-wrong subsection must exit non-zero, and the correct package must
+exit 0. `test "$(wc -l < tests/contracts.sh)" -le 250` remains true.
+
+**Document impact.** `skills/setup/SKILL.md` owns the Kiro discovery subsection;
+the contract test owns the whole-subsection match.
+
 ### 3. Five-harness onboarding and contribution surface
 
 **Behaviour.** The README consistently describes five supported harnesses and
@@ -134,7 +182,7 @@ the human harness vocabulary.
 | Requirement | Instrument | Counterexample | Observed red |
 | --- | --- | --- | --- |
 | Kiro has native install, update, removal, and `/delivery` invocation | Section-bounded README predicate plus `bash tests/contracts.sh` | A Kiro section says it is supported but tells users to copy the skills manually | 2026-08-26 in-memory probe: `wrong install rc=1`; correct shape `rc=0` |
-| Setup uses live Kiro model ids and help-derived effort | Setup Discovery structural check; live model JSON checked with `jq`; help checked for `--effort` | Kiro is present but setup uses a stored catalogue or offers `model_name` instead of `model_id` | 2026-08-26 probes: wrong Discovery `rc=1`, wrong model JSON `rc=1`; live discovery and effort surface `rc=0` |
+| Setup uses live Kiro model ids and help-derived effort | Whole `### Kiro CLI` subsection under Setup Discovery matched verbatim; live model JSON checked with `jq`; help checked for `--effort` | A Kiro subsection that keeps the live command and `model_id` but tells setup to use a stored catalogue, or that offers `model_name` instead of `model_id` | Task 2 re-review 2026-08-26: bullet-only check passed a stored-catalogue paragraph (`old=0`, `new=0`). Task 2b must observe that false pass on `73be896`, then reject it. Live model JSON and `--effort` help remain `rc=0`. |
 | Dely dispatches an interactive Kiro TUI only | AGENTS policy check names `kiro-cli chat --no-interactive` as forbidden headless dispatch | Kiro is listed as supported but a headless chat is allowed in a shell tab | 2026-08-26 in-memory probe: wrong dispatch policy `rc=1`; correct shape `rc=0` |
 | Human reports can identify all five harnesses | Issue-form option check requires the five exact harness names | The form adds Kiro but still omits Antigravity | 2026-08-26 in-memory probe: wrong options `rc=1`; correct shape `rc=0` |
 | Versioned manifests stay aligned at `0.14.0` | `bash tests/contracts.sh` reads both manifest versions | Only the Claude manifest is `0.14.0`; Codex remains `0.13.0` | 2026-08-26 in-memory predicate with split values: `rc=1` |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -9,6 +9,90 @@ Last updated 2026-08-26.
 
 ## Settled
 
+### 2026-08-26 — Kiro CLI is a first-class fifth harness
+
+#### Context
+
+Dely shipped as an installable package for Claude Code, Codex CLI, Grok Build,
+and Antigravity CLI. `dely:setup` discovered models and effort from those four
+CLIs, but it could not offer Kiro CLI. Live Kiro CLI 2.16.2 exposes an
+interactive TUI, lists models as JSON through `kiro-cli chat --list-models
+--format json`, accepts `--model` and `--effort`, and reads `AGENTS.md`
+natively. Its default agent discovers skills from `.kiro/skills/` and
+`~/.kiro/skills/`. The open `npx skills` installer supports Kiro CLI at those
+paths, and Orca 1.4.188 ships a Kiro launcher.
+
+The repository's root `plugin.json` is deliberately limited to `name` and
+`description` for Antigravity CLI 1.1.19. A Kiro Power using Agent Plugins 1.0
+would require additional root manifest fields, so one root manifest cannot
+safely serve both checked command surfaces.
+
+#### Decision
+
+Kiro CLI is a first-class harness, equal in kind to Claude Code, Codex CLI,
+Grok Build, and Antigravity CLI.
+
+Kiro installs the existing `delivery` and `setup` skills with `npx skills`,
+targeting the `kiro-cli` agent at global scope. The native Kiro commands are
+`/delivery` and `/setup`; Dely does not add a Kiro-specific package or duplicate
+the skill tree. Install, verification, update, and removal use the installer's
+documented command surface.
+
+Setup discovers Kiro models from `kiro-cli chat --list-models --format json`
+and offers each `model_id`. It reads effort choices from `kiro-cli chat --help`
+rather than prompting a model or storing a catalogue. An unavailable Kiro CLI
+or an unusable discovery result is omitted, not guessed. Setup does not write
+`~/.kiro` or create or modify custom agents. Kiro receives the managed Dely
+block through its native `AGENTS.md` support.
+
+Orca launches Kiro as a real interactive TUI and keeps its configured
+permission-bypass arguments. A headless `kiro-cli chat --no-interactive`
+process in a shell tab is not a Dely worker. The portable delivery protocol
+still names no harness and does not change. The two versioned manifests advance
+together to `0.14.0`; root `plugin.json` stays unchanged. Human bug reports
+offer all five supported harnesses.
+
+#### Alternatives considered
+
+- Package Dely as a Kiro Power at the repository root. Rejected because the
+  required Agent Plugins manifest fields conflict with the checked strict
+  Antigravity manifest.
+- Add a nested Kiro Power with a second copy of `skills/`. Rejected because it
+  creates two sources of truth for the delivery contract and templates.
+- Tell Kiro users to copy or symlink the skills manually. Rejected because
+  install, update, and removal would no longer be one verifiable public path.
+- Create a custom Kiro agent for Dely. Rejected because Dely is a workflow skill,
+  not a replacement agent, and setup does not mutate harness configuration.
+
+#### Consequences
+
+Kiro users get the same delivery and setup behaviour without a fifth package
+format. The install command depends on the external `npx skills` command and
+uses global scope, so running it intentionally mutates the user's Kiro skill
+directory; Dely itself never performs that mutation. Kiro custom agents can
+change default resource inheritance, so users of such agents remain responsible
+for including the standard Kiro skill resources.
+
+Live discovery may offer only `auto`, as observed on Kiro CLI 2.16.2. That is a
+valid live result, not a reason to invent model names. This repository's own
+phase pins remain Claude Code for implementation and Codex CLI for review.
+
+#### Non-goals
+
+No Kiro Power, `.kiro/` package, custom agent, hook, MCP server, steering file,
+or write to `~/.kiro`. No Kiro IDE, Web, Mobile, Crew, ACP, or headless dispatch.
+No Orca change. No change to review depth, remediation, the two-row managed
+block, root `plugin.json`, or `skills/delivery/SKILL.md`.
+
+#### Deferred
+
+Adopt a Kiro Power only when one package manifest can satisfy every supported
+harness without duplicating the skill tree. Configure custom-agent resources
+only when a consumer explicitly needs an agent that disables default skill
+inheritance. End-to-end global installation and live skill activation remain a
+consumer-profile check because this repository does not mutate live harness
+configuration during compatibility validation.
+
 ### 2026-08-26 — Antigravity CLI is a first-class fourth harness
 
 #### Context

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -64,8 +64,6 @@ package, from memory, or from `docs/`.
 - Codex: `codex debug models`
 - Grok models: `grok models`
 - Antigravity CLI models: `agy models` (offer the slug column of its TSV output)
-- Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each
-  `model_id`)
 
 The two Claude probes are answered locally: `num_turns` 0, `total_cost_usd` 0,
 no model turn. Do not treat them as a dispatch.
@@ -82,13 +80,16 @@ Antigravity CLI effort is `low|medium|high`, read from `agy --help`'s
 end in `-high`, `-medium`, or `-low` — that suffix names the model, not the
 effort flag, so do not strip it.
 
-Kiro CLI effort is read from `kiro-cli chat --help`'s model and effort flags;
-do not prompt the model to learn it and do not store a catalogue. Live
-discovery may offer only `auto` — that is a valid result, not a reason to
-invent model names. Omit Kiro discovery that is unavailable or unusable rather
-than guessing.
-
 A harness that is not installed is omitted from the offer, not an error.
+
+### Kiro CLI
+
+Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each
+`model_id`). Kiro CLI effort is read from `kiro-cli chat --help`'s model and
+effort flags; do not prompt the model to learn it and do not store a
+catalogue. Live discovery may offer only `auto` — that is a valid result, not
+a reason to invent model names. Omit Kiro discovery that is unavailable or
+unusable rather than guessing.
 
 ## Pinning
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -64,6 +64,8 @@ package, from memory, or from `docs/`.
 - Codex: `codex debug models`
 - Grok models: `grok models`
 - Antigravity CLI models: `agy models` (offer the slug column of its TSV output)
+- Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each
+  `model_id`)
 
 The two Claude probes are answered locally: `num_turns` 0, `total_cost_usd` 0,
 no model turn. Do not treat them as a dispatch.
@@ -79,6 +81,12 @@ Antigravity CLI effort is `low|medium|high`, read from `agy --help`'s
 `--effort` flag; do not prompt the model to learn it. Some model slugs already
 end in `-high`, `-medium`, or `-low` — that suffix names the model, not the
 effort flag, so do not strip it.
+
+Kiro CLI effort is read from `kiro-cli chat --help`'s model and effort flags;
+do not prompt the model to learn it and do not store a catalogue. Live
+discovery may offer only `auto` — that is a valid result, not a reason to
+invent model names. Omit Kiro discovery that is unavailable or unusable rather
+than guessing.
 
 A harness that is not installed is omitted from the offer, not an error.
 
@@ -123,8 +131,8 @@ authoritative.
 ## Claude Code and `AGENTS.md`
 
 Claude Code does not read `AGENTS.md`. The persistent instruction reaches
-Codex, Grok, and Antigravity CLI natively. It reaches Claude Code only where
-the project has a `CLAUDE.md` that imports `AGENTS.md`.
+Codex, Grok, Antigravity CLI, and Kiro CLI natively. It reaches Claude Code
+only where the project has a `CLAUDE.md` that imports `AGENTS.md`.
 
 Where the current harness is Claude Code and the project has no `CLAUDE.md`
 importing `AGENTS.md`, offer to create a one-line `CLAUDE.md` containing
@@ -139,8 +147,9 @@ expand the import at all.
 ## What setup will not do
 
 No plugin or skill install. No hook trust. No writes to `~/.claude`,
-`~/.codex`, `~/.grok`, or `~/.gemini`. No coordinator installation or field. No control or
-release row. No enumeration or invocation of project-owned workflow plugins.
-No model catalogue.
+`~/.codex`, `~/.grok`, `~/.gemini`, or `~/.kiro`. No custom Kiro agent creation
+or modification. No coordinator installation or field. No control or release
+row. No enumeration or invocation of project-owned workflow plugins. No model
+catalogue.
 
 Print verified install guidance only when the human explicitly asks for it.

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -103,11 +103,18 @@ if [ "$setup_block_check" != "ok" ]; then
   fail_with "$setup_skill managed block does not have exactly one implement and one review row"
 fi
 
-# Setup's Discovery section must name the live `agy models` command, not just
-# mention Antigravity in prose elsewhere in the file.
+# Setup's Discovery section must name the live `agy models` and Kiro CLI
+# commands, and offer Kiro's `model_id` field, not a stored catalogue or the
+# wrong JSON field.
 discovery_section="$(awk '/^## Discovery[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$setup_skill")"
-if ! printf '%s\n' "$discovery_section" | grep -Fq 'agy models'; then
-  fail_with "$setup_skill Discovery section does not name agy models"
+for needle in 'agy models' 'kiro-cli chat --list-models --format json' 'model_id'; do
+  printf '%s\n' "$discovery_section" | grep -Fq -- "$needle" || fail_with "$setup_skill Discovery section does not name: $needle"
+done
+
+# AGENTS.md's headless-forbidden dispatch list must name Kiro's no-interactive
+# invocation, not just list Kiro as a supported harness elsewhere.
+if ! grep -Fq 'kiro-cli chat --no-interactive' "$root/AGENTS.md"; then
+  fail_with "AGENTS.md headless-forbidden list is missing kiro-cli chat --no-interactive"
 fi
 
 # Kiro CLI's README section must document native `npx skills` install, update,
@@ -144,10 +151,8 @@ done
 # Community collaboration contract: the six community artifacts must exist,
 # and both issue forms must be present, parseable YAML with the top-level
 # keys GitHub requires to render an issue form (name, description, body).
-for f in CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md \
-         .github/ISSUE_TEMPLATE/bug_report.yml \
-         .github/ISSUE_TEMPLATE/feature_request.yml \
-         .github/pull_request_template.md; do
+for f in CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md .github/ISSUE_TEMPLATE/bug_report.yml \
+         .github/ISSUE_TEMPLATE/feature_request.yml .github/pull_request_template.md; do
   if [ ! -f "$root/$f" ]; then
     fail_with "missing required community artifact: $f"
   fi
@@ -214,23 +219,15 @@ if jobs.is_a?(Hash) && jobs.keys == ["contracts"]
   end
   run_lines = steps.flat_map { |s| (s["run"] || "").split("\n") }.map(&:strip).reject(&:empty?)
   required = [
-    'git diff --check',
-    'bash -n tests/contracts.sh',
+    'git diff --check', 'bash -n tests/contracts.sh',
     'jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json >/dev/null',
-    'bash tests/contracts.sh',
-    'test "$(wc -l < tests/contracts.sh)" -le 250',
-    'test ! -e git-hooks/pre-push',
-    'test ! -e docs/delivery-log.md',
-    'test ! -e docs/findings.md',
-    'test ! -e docs/harness-surface.md',
-    'test ! -e docs/options.md',
+    'bash tests/contracts.sh', 'test "$(wc -l < tests/contracts.sh)" -le 250',
+    'test ! -e git-hooks/pre-push', 'test ! -e docs/delivery-log.md', 'test ! -e docs/findings.md',
+    'test ! -e docs/harness-surface.md', 'test ! -e docs/options.md',
     'test ! -e docs/_plans/2026-08-24-automation-first-dely-design.md',
-    'test ! -e bin/delivery-doctor',
-    'test ! -e bin/delivery-evidence',
-    'test ! -e hooks/hooks.json',
-    'test ! -e hooks/grok-hooks.json.template',
-    'test ! -e hooks/post-tool-journal.sh',
-    'test ! -e hooks/session-start-context.sh',
+    'test ! -e bin/delivery-doctor', 'test ! -e bin/delivery-evidence',
+    'test ! -e hooks/hooks.json', 'test ! -e hooks/grok-hooks.json.template',
+    'test ! -e hooks/post-tool-journal.sh', 'test ! -e hooks/session-start-context.sh',
     "git grep -Ei 'pace.?id' -- . ':!docs/_plans' && exit 1 || true",
     "git grep -E '(^|[^A-Za-z0-9])[A-Z][0-9]+[a-z]?([^A-Za-z0-9]|$)' -- . ':!docs/_plans' && exit 1 || true",
   ]

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -103,16 +103,17 @@ if [ "$setup_block_check" != "ok" ]; then
   fail_with "$setup_skill managed block does not have exactly one implement and one review row"
 fi
 
-# Setup's Kiro CLI models bullet and AGENTS.md's headless-forbidden dispatch
-# sentence are matched verbatim: keyword presence alone still passes a bullet
-# that keeps the required strings but tells setup to use a stored catalogue,
-# or a policy reversed to "Wrap a headless ..." that keeps every command name.
+# Setup's whole "### Kiro CLI" Discovery subsection and AGENTS.md's
+# headless-forbidden dispatch sentence are matched verbatim: keyword presence
+# alone still passes a subsection that keeps the required strings but also
+# carries a contradictory paragraph (e.g. "use a stored catalogue") elsewhere
+# in Discovery, since a bullet-only or substring check cannot see it.
 norm() { tr '\n' ' ' | tr -s ' ' | sed -e 's/^ //' -e 's/ $//'; }
 discovery_section="$(awk '/^## Discovery[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$setup_skill")"
 printf '%s\n' "$discovery_section" | grep -Fq -- 'agy models' || fail_with "$setup_skill Discovery section does not name: agy models"
-expected_kiro_bullet='- Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each `model_id`)'
-actual_kiro_bullet="$(awk '/^- Kiro CLI models:/{p=1;print;next} p&&/^  /{print;next} {p=0}' "$setup_skill" | norm)"
-[ "$actual_kiro_bullet" = "$expected_kiro_bullet" ] || fail_with "$setup_skill Kiro CLI models bullet no longer matches the approved live-discovery policy verbatim"
+expected_kiro_subsection='Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each `model_id`). Kiro CLI effort is read from `kiro-cli chat --help`'\''s model and effort flags; do not prompt the model to learn it and do not store a catalogue. Live discovery may offer only `auto` — that is a valid result, not a reason to invent model names. Omit Kiro discovery that is unavailable or unusable rather than guessing.'
+actual_kiro_subsection="$(awk '/^### Kiro CLI[[:space:]]*$/{p=1;next} p && /^#/{exit} p' "$setup_skill" | norm)"
+[ "$actual_kiro_subsection" = "$expected_kiro_subsection" ] || fail_with "$setup_skill ### Kiro CLI Discovery subsection no longer matches the approved live-discovery policy verbatim"
 expected_dispatch='Load Orca'\''s native skill to launch and supervise each worker TUI. Do not wrap a headless `claude -p`, `codex exec`, `grok --prompt-file`, `agy -p`/`--print`, or `kiro-cli chat --no-interactive` in a shell tab.'
 actual_dispatch="$(awk '/^Load Orca.s native skill/{p=1} p&&/^$/{exit} p{print}' "$root/AGENTS.md" | norm)"
 [ "$actual_dispatch" = "$expected_dispatch" ] || fail_with "AGENTS.md headless-forbidden dispatch sentence no longer matches the approved policy verbatim"

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -25,9 +25,7 @@ if [ "$claude_version" != "0.14.0" ] || [ "$codex_version" != "0.14.0" ]; then
 fi
 
 root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"
-if [ "$root_name" != "dely" ]; then
-  fail_with "$root_manifest .name must be dely (got $root_name)"
-fi
+[ "$root_name" = "dely" ] || fail_with "$root_manifest .name must be dely (got $root_name)"
 
 # Canonical MIT text (github.com/licenses/mit) with [year] -> 2026 and
 # [fullname] -> Hieu Phung, whitespace-normalized. A present LICENSE that only
@@ -59,9 +57,7 @@ actual_log_section="$(awk '/^### Maintenance log$/{flag=1; next} flag && /^#/{ex
 actual_log_section="${actual_log_section# }"
 actual_log_section="${actual_log_section% }"
 
-if [ "$actual_log_section" != "$expected_log_section" ]; then
-  fail_with "maintenance log section in $skill no longer matches the approved opt-in, accepted-only, non-blocking contract verbatim"
-fi
+[ "$actual_log_section" = "$expected_log_section" ] || fail_with "maintenance log section in $skill no longer matches the approved opt-in, accepted-only, non-blocking contract verbatim"
 
 # Setup's managed block: the fenced "What to write" template must carry
 # exactly two data rows, phases {implement, review} with no duplicate or
@@ -99,9 +95,7 @@ setup_block_check="$(managed_block_template "$setup_skill" | awk '
   }
 ')"
 
-if [ "$setup_block_check" != "ok" ]; then
-  fail_with "$setup_skill managed block does not have exactly one implement and one review row"
-fi
+[ "$setup_block_check" = "ok" ] || fail_with "$setup_skill managed block does not have exactly one implement and one review row"
 
 # Setup's whole "### Kiro CLI" Discovery subsection and AGENTS.md's
 # headless-forbidden dispatch sentence are matched verbatim: keyword presence
@@ -181,6 +175,11 @@ for f in .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_re
   fi
 done
 
+# Bug form's harness dropdown must offer all five exact harness names.
+harness_options="$(awk '/^ *id: harness$/{f=1} f&&/^ *validations:/{exit} f' "$root/.github/ISSUE_TEMPLATE/bug_report.yml" | sed 's/^ *- //')"
+for h in "Claude Code" "Codex CLI" "Grok Build" "Antigravity CLI" "Kiro CLI"; do
+  printf '%s\n' "$harness_options" | grep -Fxq -- "$h" || fail_with "bug_report.yml harness dropdown is missing: $h"
+done
 
 # One CI entry point: the workflow must exist, parse as YAML, and match the
 # approved shape exactly: name, triggers, top-level permissions, the sole

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -112,7 +112,7 @@ fi
 
 # Kiro CLI's README section must document native `npx skills` install, update,
 # removal, and invocation, not just claim support with manual copying.
-kiro_section="$(awk '/^### Kiro CLI[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$root/README.md")"
+kiro_section="$(awk '/^### Kiro CLI[[:space:]]*$/{p=1;next} p && /^#{2,3} /{exit} p' "$root/README.md")"
 if [ -z "$kiro_section" ]; then
   fail_with "README.md is missing a ### Kiro CLI section"
 elif printf '%s\n' "$kiro_section" | grep -Eiq 'copy (the |both )?skills? (files? )?(manually|by hand)'; then

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -103,19 +103,19 @@ if [ "$setup_block_check" != "ok" ]; then
   fail_with "$setup_skill managed block does not have exactly one implement and one review row"
 fi
 
-# Setup's Discovery section must name the live `agy models` and Kiro CLI
-# commands, and offer Kiro's `model_id` field, not a stored catalogue or the
-# wrong JSON field.
+# Setup's Kiro CLI models bullet and AGENTS.md's headless-forbidden dispatch
+# sentence are matched verbatim: keyword presence alone still passes a bullet
+# that keeps the required strings but tells setup to use a stored catalogue,
+# or a policy reversed to "Wrap a headless ..." that keeps every command name.
+norm() { tr '\n' ' ' | tr -s ' ' | sed -e 's/^ //' -e 's/ $//'; }
 discovery_section="$(awk '/^## Discovery[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$setup_skill")"
-for needle in 'agy models' 'kiro-cli chat --list-models --format json' 'model_id'; do
-  printf '%s\n' "$discovery_section" | grep -Fq -- "$needle" || fail_with "$setup_skill Discovery section does not name: $needle"
-done
-
-# AGENTS.md's headless-forbidden dispatch list must name Kiro's no-interactive
-# invocation, not just list Kiro as a supported harness elsewhere.
-if ! grep -Fq 'kiro-cli chat --no-interactive' "$root/AGENTS.md"; then
-  fail_with "AGENTS.md headless-forbidden list is missing kiro-cli chat --no-interactive"
-fi
+printf '%s\n' "$discovery_section" | grep -Fq -- 'agy models' || fail_with "$setup_skill Discovery section does not name: agy models"
+expected_kiro_bullet='- Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each `model_id`)'
+actual_kiro_bullet="$(awk '/^- Kiro CLI models:/{p=1;print;next} p&&/^  /{print;next} {p=0}' "$setup_skill" | norm)"
+[ "$actual_kiro_bullet" = "$expected_kiro_bullet" ] || fail_with "$setup_skill Kiro CLI models bullet no longer matches the approved live-discovery policy verbatim"
+expected_dispatch='Load Orca'\''s native skill to launch and supervise each worker TUI. Do not wrap a headless `claude -p`, `codex exec`, `grok --prompt-file`, `agy -p`/`--print`, or `kiro-cli chat --no-interactive` in a shell tab.'
+actual_dispatch="$(awk '/^Load Orca.s native skill/{p=1} p&&/^$/{exit} p{print}' "$root/AGENTS.md" | norm)"
+[ "$actual_dispatch" = "$expected_dispatch" ] || fail_with "AGENTS.md headless-forbidden dispatch sentence no longer matches the approved policy verbatim"
 
 # Kiro CLI's README section must document native `npx skills` install, update,
 # removal, and invocation, not just claim support with manual copying.

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -20,8 +20,8 @@ skill="$root/skills/delivery/SKILL.md"
 claude_version="$(jq -r .version "$claude_manifest" 2>/dev/null)"
 codex_version="$(jq -r .version "$codex_manifest" 2>/dev/null)"
 
-if [ "$claude_version" != "0.13.0" ] || [ "$codex_version" != "0.13.0" ]; then
-  fail_with "manifest versions must both be 0.13.0 (claude=$claude_version codex=$codex_version)"
+if [ "$claude_version" != "0.14.0" ] || [ "$codex_version" != "0.14.0" ]; then
+  fail_with "manifest versions must both be 0.14.0 (claude=$claude_version codex=$codex_version)"
 fi
 
 root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"
@@ -108,6 +108,20 @@ fi
 discovery_section="$(awk '/^## Discovery[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$setup_skill")"
 if ! printf '%s\n' "$discovery_section" | grep -Fq 'agy models'; then
   fail_with "$setup_skill Discovery section does not name agy models"
+fi
+
+# Kiro CLI's README section must document native `npx skills` install, update,
+# removal, and invocation, not just claim support with manual copying.
+kiro_section="$(awk '/^### Kiro CLI[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$root/README.md")"
+if [ -z "$kiro_section" ]; then
+  fail_with "README.md is missing a ### Kiro CLI section"
+elif printf '%s\n' "$kiro_section" | grep -Eiq 'copy (the |both )?skills? (files? )?(manually|by hand)'; then
+  fail_with "README.md Kiro CLI section instructs manual copying instead of npx skills"
+else
+  for needle in 'npx skills add' 'npx skills update' 'npx skills remove' \
+                '--agent kiro-cli' '--global' '--skill delivery' '--skill setup' '/delivery' '/setup'; do
+    printf '%s\n' "$kiro_section" | grep -Fq -- "$needle" || fail_with "README.md Kiro CLI section is missing: $needle"
+  done
 fi
 
 # Plan template's acceptance header: the four named columns must all be


### PR DESCRIPTION
## What does this change?

Adds Kiro CLI as a first-class fifth harness: native `npx skills` install of the existing `delivery` and `setup` skills, live model/effort discovery in `dely:setup`, interactive Orca TUI dispatch only, and five-harness README plus bug-form coverage. Versioned manifests move together to `0.14.0`. Root `plugin.json` is unchanged.

## Scope

- `README.md` — Kiro install/update/remove/`/delivery`, five-harness onboarding
- `skills/setup/SKILL.md` — live Kiro discovery under `### Kiro CLI`
- `AGENTS.md` — support matrix and forbidden `kiro-cli chat --no-interactive`
- `.github/ISSUE_TEMPLATE/bug_report.yml` — five harness options
- `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json` — `0.14.0`
- `docs/decisions.md`, `docs/_plans/2026-08-26-kiro-cli-support.md`
- `tests/contracts.sh` — discriminating contract checks (≤ 250 lines)

Out of reach: Kiro Power, custom agents, `~/.kiro` writes, hooks, MCP, headless dispatch, Orca changes, `skills/delivery/SKILL.md`.

Related: Architectural delivery on `feat/kiro-cli-support` from `main` at `b79ea56`. Design baseline `279f9f4`. Candidate HEAD `a914a14`.

## Verification

From the repository root, all `AGENTS.md` closure gates are green at `a914a14`, including `bash tests/contracts.sh` and `test "$(wc -l < tests/contracts.sh)" -le 250` (247 lines).

Focused counterexamples reproduced during task reviews:

- README Kiro section that instructs manual copying is rejected; `npx skills` section is accepted
- Setup `### Kiro CLI` subsection that keeps the live command/`model_id` but tells setup to use a stored catalogue is rejected
- Headless-forbidden dispatch sentence is matched verbatim, including `kiro-cli chat --no-interactive`
- Bug form that adds Kiro but omits Antigravity is rejected; the five exact names are accepted

## Contract and documentation impact

Yes. Public install, setup discovery, deployment policy, bug-form harness vocabulary, and both versioned manifests change. README, AGENTS.md, and `docs/decisions.md` are updated in this pull request. `skills/delivery/SKILL.md` stays portable and harness-neutral.