### PR TITLE
Reconcile Kiro onboarding wording after live-probe review

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ orca status --json   # confirms the runtime is reachable
 ## Install
 
 The plugin is `dely`, served from the `dely` marketplace at
-`https://github.com/hieuphung97/dely.git`. Install it in each harness from
-that remote. The skill keeps the name `delivery`; the intended namespaced
-name is `dely:delivery`. The marketplace entry keeps `"source": "./"`, which
-is what makes the plugin resolve inside its own repository whether the
-marketplace is added by path or by git URL.
+`https://github.com/hieuphung97/dely.git`. Install it in each of the four
+plugin harnesses — Claude Code, Codex CLI, Grok Build, and Antigravity CLI —
+from that remote. The skill keeps the name `delivery`; the intended
+namespaced name is `dely:delivery`. The marketplace entry keeps
+`"source": "./"`, which is what makes the plugin resolve inside its own
+repository whether the marketplace is added by path or by git URL. Kiro CLI
+has no plugin verb; see `### Kiro CLI` below for its `npx skills` install.
 
 ### Claude Code
 
@@ -147,12 +149,20 @@ as `/delivery` and `/setup`.
 
 ### Cache refresh boundary
 
-All five harnesses run a **copy** of this package taken at install time, so
-editing the source changes nothing until each cache is refreshed. Bump the
+The four plugin harnesses — Claude Code, Codex CLI, Grok Build, and
+Antigravity CLI — each run a **copy** of this package taken at install time,
+so editing the source changes nothing until each cache is refreshed. Bump the
 version and refresh every copy whenever a rule changes, or the harnesses
-disagree about what the workflow says. A self-update's release phase runs
-through the frozen installed plugin version already in use for that plan;
-candidate changes take effect starting with the next delivery.
+disagree about what the workflow says.
+
+Kiro CLI instead reads from a shared store, usually a symlink into this
+checkout. `npx skills update --global` refreshes it by comparing a folder
+hash, not the `0.14.0` version string. `update` takes no `--agent`/`--skill`
+because the store is shared.
+
+A self-update's release phase runs through the frozen installed plugin
+version already in use for that plan; candidate changes take effect starting
+with the next delivery.
 
 ## Setup
 

--- a/skills/delivery/SKILL.md
+++ b/skills/delivery/SKILL.md
@@ -141,8 +141,8 @@ changes without announcing itself, and the dispatch that relies on it looks
 identical to one that pinned the same value deliberately.
 
 When composing the TUI launch argv yourself, keep the execution plane's
-default permission-bypass flags. Do not add a sandbox the project did not
-pin.
+launch command as-is; do not add permission-bypass flags it does not already
+carry; do not add a sandbox the project did not pin.
 
 Keep waiting blocking. A worker is observed through Orca until it completes
 or its timeout fires. Do not add a relay, poll, or state machine to

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -85,11 +85,11 @@ A harness that is not installed is omitted from the offer, not an error.
 ### Kiro CLI
 
 Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each
-`model_id`). Kiro CLI effort is read from `kiro-cli chat --help`'s model and
-effort flags; do not prompt the model to learn it and do not store a
-catalogue. Live discovery may offer only `auto` — that is a valid result, not
-a reason to invent model names. Omit Kiro discovery that is unavailable or
-unusable rather than guessing.
+`model_id`). Kiro CLI effort is read from `kiro-cli chat --help`'s `--effort`
+flag; do not prompt the model to learn it and do not store a catalogue. Live
+discovery may offer only `auto` — that is a valid result, not a reason to
+invent model names. Omit Kiro discovery that is unavailable or unusable
+rather than guessing.
 
 ## Pinning
 
@@ -142,8 +142,8 @@ importing `AGENTS.md`, offer to create a one-line `CLAUDE.md` containing
 This is not a second managed block: no markers, no configuration, a pointer
 at the block rather than a copy of it.
 
-The offer is Claude-Code-only. On Codex the file is inert, and Grok does not
-expand the import at all.
+The offer is Claude-Code-only. On Codex, Antigravity CLI, and Kiro CLI the
+file is inert; Grok does not expand it.
 
 ## What setup will not do
 

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -59,6 +59,8 @@ actual_log_section="${actual_log_section% }"
 
 [ "$actual_log_section" = "$expected_log_section" ] || fail_with "maintenance log section in $skill no longer matches the approved opt-in, accepted-only, non-blocking contract verbatim"
 
+grep -Fq "launch command as-is" "$skill" && ! grep -Fq 'default permission-bypass flags' "$skill" || fail_with "$skill launch-argv guidance still names the old harness-default permission-bypass wording"
+
 # Setup's managed block: the fenced "What to write" template must carry
 # exactly two data rows, phases {implement, review} with no duplicate or
 # extra phase (e.g. a lingering control/release row). Word-presence alone
@@ -100,12 +102,13 @@ setup_block_check="$(managed_block_template "$setup_skill" | awk '
 # Setup's whole "### Kiro CLI" Discovery subsection and AGENTS.md's
 # headless-forbidden dispatch sentence are matched verbatim: keyword presence
 # alone still passes a subsection that keeps the required strings but also
-# carries a contradictory paragraph (e.g. "use a stored catalogue") elsewhere
-# in Discovery, since a bullet-only or substring check cannot see it.
+# carries a contradictory clause within that same subsection (e.g. "use a
+# stored catalogue"); the check only matches that subsection, not the rest of
+# Discovery.
 norm() { tr '\n' ' ' | tr -s ' ' | sed -e 's/^ //' -e 's/ $//'; }
 discovery_section="$(awk '/^## Discovery[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$setup_skill")"
 printf '%s\n' "$discovery_section" | grep -Fq -- 'agy models' || fail_with "$setup_skill Discovery section does not name: agy models"
-expected_kiro_subsection='Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each `model_id`). Kiro CLI effort is read from `kiro-cli chat --help`'\''s model and effort flags; do not prompt the model to learn it and do not store a catalogue. Live discovery may offer only `auto` — that is a valid result, not a reason to invent model names. Omit Kiro discovery that is unavailable or unusable rather than guessing.'
+expected_kiro_subsection='Kiro CLI models: `kiro-cli chat --list-models --format json` (offer each `model_id`). Kiro CLI effort is read from `kiro-cli chat --help`'\''s `--effort` flag; do not prompt the model to learn it and do not store a catalogue. Live discovery may offer only `auto` — that is a valid result, not a reason to invent model names. Omit Kiro discovery that is unavailable or unusable rather than guessing.'
 actual_kiro_subsection="$(awk '/^### Kiro CLI[[:space:]]*$/{p=1;next} p && /^#/{exit} p' "$setup_skill" | norm)"
 [ "$actual_kiro_subsection" = "$expected_kiro_subsection" ] || fail_with "$setup_skill ### Kiro CLI Discovery subsection no longer matches the approved live-discovery policy verbatim"
 expected_dispatch='Load Orca'\''s native skill to launch and supervise each worker TUI. Do not wrap a headless `claude -p`, `codex exec`, `grok --prompt-file`, `agy -p`/`--print`, or `kiro-cli chat --no-interactive` in a shell tab. Kiro workers launch as an interactive TUI, `kiro-cli chat --tui` with `--model` and `--effort` pinned from the managed block and no `--trust-all-tools` on that argv; once the TUI is idle at its prompt, send `/tools trust-all`, then the work prompt.'


### PR DESCRIPTION
## What does this change?

Bounded wording fix after the live-probe review of Kiro CLI onboarding.

Portable delivery launch guidance no longer tells a consumer to keep a harness-default permission-bypass flag. README Install and cache-refresh now scope the plugin copy/version workflow to the four plugin harnesses and describe Kiro CLI's `npx skills` / shared-store path separately. Setup names all three harnesses where `CLAUDE.md` is inert, and Kiro effort discovery cites `--effort` only. `tests/contracts.sh` guards the corrected launch wording, updates the Kiro subsection verbatim, and no longer claims that check covers the rest of Discovery.

## Scope

- `README.md`
- `skills/delivery/SKILL.md`
- `skills/setup/SKILL.md`
- `tests/contracts.sh`

Out of this PR: `/skill` vs `/delivery` until TUI `/help` confirms it; `v0.13.0` pin examples (Codex/Grok, separate commit); writing `~/.kiro`; widening the Discovery parser.

## Verification

Independent review **ACCEPT** on exact HEAD `1945bb8` (Claude Code, opus, high; session `4445b7bd-c2f4-4394-a0ce-a01b20f63d52`). Codex `gpt-5.6-sol` was unavailable (`invalid_request_error` / model metadata not found), so review used the session override.

Local closure gates on `1945bb8` (repo root): `git diff --check`, `bash -n tests/contracts.sh`, `jq -e .` on the four manifests, `bash tests/contracts.sh` (exit 0), `wc -l tests/contracts.sh` = 250, 12 absence tests, both disclosure greps. Negative fixtures: restoring the old launch-argv phrase fails the new guard; restoring "model and effort flags" fails the Kiro verbatim check.

## Contract and documentation impact

Public wording only: portable launch argv, README install/cache boundary, Setup Kiro effort and `CLAUDE.md` offer. No new harness, no pin change, no `AGENTS.md` managed-block change, no `docs/decisions.md` change.