### PR TITLE
fix: restore the composed-argv permission default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,12 @@ delivery run.
 <!-- dely:end -->
 
 The table is this repository's deployment selection, not the portable protocol.
+Prefer Orca's `--agent` launcher whenever it can pin the block's model and
+effort. Use hand-composed argv only where it cannot, and there carry that
+harness's permission default: Claude Code `--dangerously-skip-permissions`,
+Codex CLI `--dangerously-bypass-approvals-and-sandbox`, Grok
+`--permission-mode bypassPermissions`, Antigravity CLI
+`--dangerously-skip-permissions`.
 Load Orca's native skill to launch and supervise each worker TUI. Do not wrap a
 headless `claude -p`, `codex exec`, `grok --prompt-file`, `agy -p`/`--print`, or
 `kiro-cli chat --no-interactive` in a shell tab. Kiro workers launch as an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,15 +40,13 @@ Name the model and reasoning effort on every dispatch.
 <!-- dely:begin -->
 ## Dely
 
-Bounded or Architectural work invokes `dely:delivery`. Orca is the required
-execution plane, so there is no coordinator field; there is no control row
-because the current interactive session already exists, and no release row
-because release has no LLM worker.
+Bounded or Architectural work invokes `dely:delivery`; Spike starts no
+delivery run.
 
 | Phase | Harness | Model | Effort |
 | --- | --- | --- | --- |
-| `implement` | Claude Code | `sonnet` | `medium` |
-| `review` | Codex CLI | `gpt-5.6-sol` | `high` |
+| `implement` | Grok Build | `grok-4.6` | `medium` |
+| `review` | Claude Code | `opus` | `high` |
 <!-- dely:end -->
 
 The table is this repository's deployment selection, not the portable protocol.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3,11 +3,58 @@
 What has been settled, what is still open, and what was rejected and why.
 Rationale is kept because the reasons are the reusable part.
 
-Last updated 2026-08-26.
+Last updated 2026-08-27.
 
 ---
 
 ## Settled
+
+### 2026-08-27 — Composed TUI argv carries the execution plane's permission default
+
+#### Context
+
+Commit `538bf9d` required Control, when composing a TUI launch argv itself, to
+keep the execution plane's default permission-bypass flags for that harness
+and add no unpinned sandbox. Twelve hours later, `1945bb8` rewrote that
+sentence to stay harness-agnostic after a Kiro live-probe review. The rewrite
+said to keep the launch command as-is and not add permission-bypass flags the
+command did not already carry. That inverts the rule: Orca applies permission
+defaults only on its `--agent` launcher path, and a hand-composed
+`orca terminal create --command` gets none of them. Grok, Antigravity CLI, and
+Kiro CLI cannot use launch-time model selection on `--agent`, so every
+dispatch of those harnesses is composed by hand and hits the defect. The
+released `v0.14.0` tag (`5c12c26`) carries the inversion, and a lexical
+contract check required the inverted wording.
+
+#### Decision
+
+The portable delivery rule is restored without naming a harness. Composing
+the TUI launch argv is not a request for a different permission posture than
+the one the execution plane is already configured to apply for that agent;
+that configured default is carried onto the composed argv. The rule still
+forbids adding a sandbox the project did not pin. Kiro CLI's existing
+exception stands: `--trust-all-tools` does not go on the argv.
+
+This repository's `AGENTS.md` prefers Orca's `--agent` launcher whenever it
+can pin the block's model and effort, and names the per-harness permission
+default used when argv is composed by hand.
+
+#### Alternatives considered
+
+- Keep the inverted as-is wording because it is harness-agnostic. Rejected:
+  agnostic wording that drops the configured default is the defect.
+- Name harness-specific bypass flags in the portable skill. Rejected: that is
+  what `1945bb8` set out to undo, and Kiro's default is not a bypass flag on
+  argv.
+- Rely on Orca's `--agent` path only. Rejected: three harnesses cannot pin
+  model and effort that way, and `AGENTS.md` requires both on every dispatch.
+
+#### Consequences
+
+Hand-composed launches match the host's configured agent-tab permission
+posture. The contract check now rejects the `v0.14.0` skill text. Live TUI
+permission posture has no automated instrument; Control confirms it by
+launching the composed argv and reading the TUI.
 
 ### 2026-08-26 — Kiro CLI is a first-class fifth harness
 

--- a/skills/delivery/SKILL.md
+++ b/skills/delivery/SKILL.md
@@ -140,9 +140,10 @@ default is an unpinned environment: it lives in the harness's own config, it
 changes without announcing itself, and the dispatch that relies on it looks
 identical to one that pinned the same value deliberately.
 
-When composing the TUI launch argv yourself, keep the execution plane's
-launch command as-is; do not add permission-bypass flags it does not already
-carry; do not add a sandbox the project did not pin.
+When composing the TUI launch argv yourself, carry the execution plane's
+configured permission default for that agent onto the composed argv;
+composing argv is not a request for a different permission posture. Do not
+add a sandbox the project did not pin.
 
 Keep waiting blocking. A worker is observed through Orca until it completes
 or its timeout fires. Do not add a relay, poll, or state machine to

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -59,7 +59,10 @@ actual_log_section="${actual_log_section% }"
 
 [ "$actual_log_section" = "$expected_log_section" ] || fail_with "maintenance log section in $skill no longer matches the approved opt-in, accepted-only, non-blocking contract verbatim"
 
-grep -Fq "launch command as-is" "$skill" && ! grep -Fq 'default permission-bypass flags' "$skill" || fail_with "$skill launch-argv guidance still names the old harness-default permission-bypass wording"
+# Restored launch rule: carry the configured permission default, not as-is.
+grep -Fq 'configured permission default' "$skill" && grep -Fq 'sandbox the project did not pin' "$skill" && ! grep -Fq 'launch command as-is' "$skill" || fail_with "$skill launch-argv guidance does not carry the execution plane's configured permission default onto composed argv"
+# Hand-composed-argv harnesses must name their permission default.
+grep -Fq -- '--permission-mode bypassPermissions' "$root/AGENTS.md" && grep -Fq -- '--dangerously-skip-permissions' "$root/AGENTS.md" && grep -Fq -- '--trust-all-tools' "$root/AGENTS.md" || fail_with "AGENTS.md does not name a permission default for each hand-composed-argv harness"
 
 # Setup's managed block: the fenced "What to write" template must carry
 # exactly two data rows, phases {implement, review} with no duplicate or
@@ -100,11 +103,7 @@ setup_block_check="$(managed_block_template "$setup_skill" | awk '
 [ "$setup_block_check" = "ok" ] || fail_with "$setup_skill managed block does not have exactly one implement and one review row"
 
 # Setup's whole "### Kiro CLI" Discovery subsection and AGENTS.md's
-# headless-forbidden dispatch sentence are matched verbatim: keyword presence
-# alone still passes a subsection that keeps the required strings but also
-# carries a contradictory clause within that same subsection (e.g. "use a
-# stored catalogue"); the check only matches that subsection, not the rest of
-# Discovery.
+# headless-forbidden dispatch sentence are matched verbatim.
 norm() { tr '\n' ' ' | tr -s ' ' | sed -e 's/^ //' -e 's/ $//'; }
 discovery_section="$(awk '/^## Discovery[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$setup_skill")"
 printf '%s\n' "$discovery_section" | grep -Fq -- 'agy models' || fail_with "$setup_skill Discovery section does not name: agy models"


### PR DESCRIPTION
## What does this change?

`v0.14.0` (`5c12c26`) ships an inverted worker-launch rule. `538bf9d` had added:

> keep the execution plane's **default permission-bypass flags** for that harness

Twelve hours later `1945bb8`, a wording reconciliation whose goal was to drop a
harness-specific reference from the portable protocol, rewrote it as:

> keep the execution plane's **launch command as-is; do not add** permission-bypass flags it does not already carry

That inverts the rule. Orca applies its per-agent permission default only on the
`--agent <id>` launcher path; a hand-composed `orca terminal create --command`
argv gets none of it. Orca also refuses launch-time model selection for
`antigravity`, `grok`, and `kiro`, and this project requires a model and effort
on every dispatch — so those three can only be launched through composed argv,
and hit the defect on every dispatch.

Observed live: `--agent claude --model sonnet --effort medium` produced
`claude --dangerously-skip-permissions --model sonnet --effort medium`, while
`terminal create --command "claude --model sonnet"` produced a TUI reading
`auto mode on`. On `agy` 1.1.22 a trivial `echo` raised `Requesting permission
for: ... Do you want to proceed?` without the flag and ran silently with it.

The same reconciliation added a `contracts.sh` check that fails if the correct
wording returns, so the regression was held in place by a contract gate.

## Scope

- `skills/delivery/SKILL.md` — rule restored, still harness-agnostic
- `AGENTS.md` — prefer Orca's `--agent` launcher where it can pin model and
  effort; name the permission default per harness where it cannot. The Kiro
  exception is unchanged: `--trust-all-tools` stays off the argv because it
  opens a confirmation defaulting to "No, exit".
- `tests/contracts.sh` — the check that locked the inversion now locks the
  restored rule, plus a new check that `AGENTS.md` names each flag
- `docs/decisions.md` — one Settled entry for 2026-08-27

No manifest or version change.

## Verification

All closure gates green on `2cced10`: `git diff --check`, `bash -n
tests/contracts.sh`, `jq -e .` on the four manifests, `bash tests/contracts.sh`,
the 250-line cap (249), the absence gates, and both disclosure greps.

Both new checks were confirmed discriminating, not merely baseline-red: run
against `git show 5c12c26:skills/delivery/SKILL.md` and `5c12c26:AGENTS.md` —
files that exist, read plausibly, and pass the old gate — they go red; on HEAD
they pass.

Live TUI permission posture has no automated instrument. The manual probe is
`orca terminal create --command "<argv>"` followed by reading the TUI. This
delivery's own implementer was dispatched that way and its TUI footer read
`Grok 4.6 (medium) · always-approve`.

## Contract and documentation impact

`skills/delivery/SKILL.md` is the portable protocol consumers install, so this
is a public-contract change. `AGENTS.md` and `docs/decisions.md` are reconciled
in the same commit. `README.md` needs no change — it documents install, not
dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)