### PR TITLE
chore: bump package version to 0.14.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ disagree about what the workflow says.
 
 Kiro CLI instead reads from a shared store, usually a symlink into this
 checkout. `npx skills update --global` refreshes it by comparing a folder
-hash, not the `0.14.0` version string. `update` takes no `--agent`/`--skill`
+hash, not the `0.14.1` version string. `update` takes no `--agent`/`--skill`
 because the store is shared.
 
 A self-update's release phase runs through the frozen installed plugin

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -20,8 +20,8 @@ skill="$root/skills/delivery/SKILL.md"
 claude_version="$(jq -r .version "$claude_manifest" 2>/dev/null)"
 codex_version="$(jq -r .version "$codex_manifest" 2>/dev/null)"
 
-if [ "$claude_version" != "0.14.0" ] || [ "$codex_version" != "0.14.0" ]; then
-  fail_with "manifest versions must both be 0.14.0 (claude=$claude_version codex=$codex_version)"
+if [ "$claude_version" != "0.14.1" ] || [ "$codex_version" != "0.14.1" ]; then
+  fail_with "manifest versions must both be 0.14.1 (claude=$claude_version codex=$codex_version)"
 fi
 
 root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"


### PR DESCRIPTION
## What does this change?

PR #26 changed a rule in `skills/delivery/SKILL.md` without advancing the
version. `README.md` states this project's own invariant:

> Bump the version and refresh every copy whenever a rule changes, or the
> harnesses disagree about what the workflow says.

The four plugin harnesses each run a copy taken at install time, so an unbumped
rule change installs under a version string already in use — the exact condition
that let the `1945bb8` inversion sit undetected inside `0.14.0`. This restores
the invariant for the shipped fix.

## Scope

- `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json` — the two versioned
  manifests advance together to `0.14.1`
- `tests/contracts.sh` — the pin and its failure message
- `README.md` — the live version reference in the Kiro refresh paragraph

Root `plugin.json` is untouched: it carries no version by design, for the
Antigravity manifest schema. `docs/decisions.md` is untouched: its `v0.14.0`
references are historical statements about what that release contained, and
remain true.

## Verification

All closure gates green on `1c28560`: `git diff --check`, `bash -n
tests/contracts.sh`, `jq -e .` on the four manifests, `bash tests/contracts.sh`,
the 250-line cap (249), and both disclosure greps.

The acceptance instrument was confirmed discriminating against the final
`contracts.sh`, not only the intermediate state: setting `.codex-plugin` back to
`0.14.0` while `.claude-plugin` reads `0.14.1` — a state that exists, runs, and
is wrong — turns `bash tests/contracts.sh` red.

`git grep '0\.14\.0'` returns nothing outside `docs/decisions.md`.

## Contract and documentation impact

No behaviour or documented command changes. `README.md` is reconciled in the
same commit. A `v0.14.1` tag follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)