### PR TITLE
Stop labelling Cursor's marketplace remove as uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,10 @@ collaborators on this repository (project scope)`).
 To uninstall, go to the `Installed` tab instead, select `dely`, and choose
 `Uninstall`. There is no non-interactive uninstall command;
 `cursor-agent plugin marketplace remove` only removes the marketplace entry
-and leaves the plugin installed.
+and leaves the plugin installed. That `Uninstall` action only appears for a
+`dely` installed through Cursor's own marketplace; a `dely` installed through
+Claude Code shows as `dely (Claude Code)` in the same `Installed` tab with
+only `Try in chat`, and is not uninstallable from Cursor.
 
 Cursor does not namespace plugin skills the way Claude Code does with
 `dely:setup`; with another plugin also installed, the palette can show more

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ cursor-agent plugin marketplace list
 # update
 cursor-agent plugin marketplace update dely
 
-# uninstall
+# removes the marketplace, not the plugin
 cursor-agent plugin marketplace remove dely
 ```
 
@@ -153,6 +153,11 @@ with the left and right arrows or Tab. Go to the `Marketplace` tab, type
 `dely` in the search box, and press Enter on the `dely (dely)` result, then choose
 `Install for you (user scope)` (the other offered action is `Install for all
 collaborators on this repository (project scope)`).
+
+To uninstall, go to the `Installed` tab instead, select `dely`, and choose
+`Uninstall`. There is no non-interactive uninstall command;
+`cursor-agent plugin marketplace remove` only removes the marketplace entry
+and leaves the plugin installed.
 
 Cursor does not namespace plugin skills the way Claude Code does with
 `dely:setup`; with another plugin also installed, the palette can show more

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -9,6 +9,61 @@ Last updated 2026-08-28.
 
 ## Settled
 
+### 2026-08-28 — README's Cursor uninstall step names the marketplace, not the plugin
+
+#### Context
+
+`README.md`'s `### Cursor Agent CLI` fenced block labelled
+`cursor-agent plugin marketplace remove dely` as `# uninstall`. It does not
+uninstall. Verified twice on cursor-agent 2026.08.25-3e8eec8: after running
+it, a new Cursor session still listed `dely` in `/plugin` → `Installed` with
+both skills present. Cursor's own CLI changelog (2026-07-13) defines
+`plugin marketplace remove` as deleting a user-scoped marketplace; installed
+plugins are unaffected. Every other harness section in the README pairs
+`# uninstall` with a command that actually uninstalls.
+
+Uninstalling is interactive: `/plugin` → `Installed` → select `dely` →
+`Uninstall`, observed present on a Cursor-managed install. That action
+appears only for plugins Cursor manages; Cursor also lists Claude Code's own
+installed plugins in the same panel, labelled `(Claude Code)`, offering only
+`Try in chat`. Cursor staff, forum, 2026-07: "There isn't a separate
+non-interactive command like `cursor-agent plugin install <plugin-id>` yet."
+There is no non-interactive install or uninstall command for either harness's
+plugins.
+
+#### Decision
+
+The fenced block's comment now says what `plugin marketplace remove` does —
+removes the marketplace, not the plugin. The prose tells the reader that
+uninstalling `dely` itself happens in `/plugin` → `Installed` → `Uninstall`,
+and that no non-interactive command exists for it. `tests/contracts.sh` pins
+the new comment text as a needle inside the existing Cursor needle loop, so a
+half-edit that fixes the prose but leaves the fenced block's `# uninstall`
+still fails contracts.
+
+#### Alternatives considered
+
+- Say uninstalling is impossible. Rejected: it is possible, just interactive.
+- Drop the `remove` command from the fenced block. Rejected: it is still a
+  real, useful command — it just isn't uninstall.
+
+#### Consequences
+
+The Cursor section stops promising a working `# uninstall` command that
+silently no-ops. Readers who copy the fenced block get an accurate comment;
+readers who want to actually uninstall are pointed at `/plugin` →
+`Installed`.
+
+#### Non-goals
+
+No change to the four `plugin marketplace` commands, to `/plugin`, `/dely`,
+`/delivery`, `/setup`, or to any other harness section.
+
+#### Deferred
+
+Document a non-interactive Cursor uninstall command if and when Cursor ships
+one.
+
 ### 2026-08-28 — Harness launch mechanics ship inside the delivery skill
 
 #### Context

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3,7 +3,7 @@
 What has been settled, what is still open, and what was rejected and why.
 Rationale is kept because the reasons are the reusable part.
 
-Last updated 2026-08-28.
+Last updated 2026-08-29.
 
 ---
 
@@ -28,18 +28,24 @@ appears only for plugins Cursor manages; Cursor also lists Claude Code's own
 installed plugins in the same panel, labelled `(Claude Code)`, offering only
 `Try in chat`. Cursor staff, forum, 2026-07: "There isn't a separate
 non-interactive command like `cursor-agent plugin install <plugin-id>` yet."
-There is no non-interactive install or uninstall command for either harness's
-plugins.
+There is no non-interactive install or uninstall command from `cursor-agent`
+itself (Claude Code has one, `claude plugin uninstall dely`, documented in
+this repository's own `README.md`).
 
 #### Decision
 
 The fenced block's comment now says what `plugin marketplace remove` does —
 removes the marketplace, not the plugin. The prose tells the reader that
 uninstalling `dely` itself happens in `/plugin` → `Installed` → `Uninstall`,
-and that no non-interactive command exists for it. `tests/contracts.sh` pins
-the new comment text as a needle inside the existing Cursor needle loop, so a
-half-edit that fixes the prose but leaves the fenced block's `# uninstall`
-still fails contracts.
+that no non-interactive command exists for it, and that the `Uninstall`
+action is absent for a `dely` installed through Claude Code.
+`tests/contracts.sh` extracts the fenced block on its own and requires all
+four `plugin marketplace` commands plus the new comment inside it, and
+separately forbids `# uninstall` from appearing anywhere in the Cursor
+section, so a half-edit that fixes the prose but leaves the fenced block's
+`# uninstall` — or that re-adds `# uninstall` beside the fence's `remove`
+line while keeping the new comment elsewhere in the block — still fails
+contracts.
 
 #### Alternatives considered
 

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -144,7 +144,7 @@ printf '%s\n' "$cursor_section" | grep -Eiq 'copy (the |both )?skills? (files? )
 cursor_fence="$(printf '%s\n' "$cursor_section" | awk '/^```/{f=!f;next} f')"
 for needle in 'plugin marketplace add' 'plugin marketplace list' 'plugin marketplace update' 'plugin marketplace remove' '# removes the marketplace, not the plugin'; do printf '%s\n' "$cursor_fence" | grep -Fq -- "$needle" || fail_with "README.md Cursor Agent CLI fenced block is missing: $needle"; done
 for needle in '`/plugin`' '`/dely`' '/delivery' '/setup'; do printf '%s\n' "$cursor_section" | grep -Fq -- "$needle" || fail_with "README.md Cursor Agent CLI section is missing: $needle"; done
-for needle in '/add-plugin' '# uninstall'; do printf '%s\n' "$cursor_section" | grep -Fq -- "$needle" && fail_with "README.md Cursor Agent CLI section must not contain: $needle" || true; done
+for needle in '/add-plugin' '#[[:space:]]*uninstall'; do printf '%s\n' "$cursor_section" | grep -Eiq -- "$needle" && fail_with "README.md Cursor Agent CLI section must not contain: $needle" || true; done
 
 # Plan template's acceptance header: the four named columns must all be present.
 plan_template="$root/skills/delivery/templates/plan.md"

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -141,7 +141,7 @@ cursor_section="$(readme_section 'Cursor Agent CLI')"
 [ -n "$cursor_section" ] || fail_with "README.md is missing a ### Cursor Agent CLI section"
 printf '%s\n' "$cursor_section" | grep -Fiq 'npx skills' && fail_with "README.md Cursor Agent CLI section must not document npx skills" || true
 printf '%s\n' "$cursor_section" | grep -Eiq 'copy (the |both )?skills? (files? )?(manually|by hand)' && fail_with "README.md Cursor Agent CLI section instructs manual copying instead of plugin marketplace add" || true
-for needle in 'plugin marketplace add' '`/plugin`' '`/dely`' '/delivery' '/setup'; do
+for needle in 'plugin marketplace add' '`/plugin`' '`/dely`' '/delivery' '/setup' '# removes the marketplace, not the plugin'; do
   printf '%s\n' "$cursor_section" | grep -Fq -- "$needle" || fail_with "README.md Cursor Agent CLI section is missing: $needle"
 done
 printf '%s\n' "$cursor_section" | grep -Fq -- '/add-plugin' && fail_with "README.md Cursor Agent CLI section must not document /add-plugin" || true

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -141,10 +141,10 @@ cursor_section="$(readme_section 'Cursor Agent CLI')"
 [ -n "$cursor_section" ] || fail_with "README.md is missing a ### Cursor Agent CLI section"
 printf '%s\n' "$cursor_section" | grep -Fiq 'npx skills' && fail_with "README.md Cursor Agent CLI section must not document npx skills" || true
 printf '%s\n' "$cursor_section" | grep -Eiq 'copy (the |both )?skills? (files? )?(manually|by hand)' && fail_with "README.md Cursor Agent CLI section instructs manual copying instead of plugin marketplace add" || true
-for needle in 'plugin marketplace add' '`/plugin`' '`/dely`' '/delivery' '/setup' '# removes the marketplace, not the plugin'; do
-  printf '%s\n' "$cursor_section" | grep -Fq -- "$needle" || fail_with "README.md Cursor Agent CLI section is missing: $needle"
-done
-printf '%s\n' "$cursor_section" | grep -Fq -- '/add-plugin' && fail_with "README.md Cursor Agent CLI section must not document /add-plugin" || true
+cursor_fence="$(printf '%s\n' "$cursor_section" | awk '/^```/{f=!f;next} f')"
+for needle in 'plugin marketplace add' 'plugin marketplace list' 'plugin marketplace update' 'plugin marketplace remove' '# removes the marketplace, not the plugin'; do printf '%s\n' "$cursor_fence" | grep -Fq -- "$needle" || fail_with "README.md Cursor Agent CLI fenced block is missing: $needle"; done
+for needle in '`/plugin`' '`/dely`' '/delivery' '/setup'; do printf '%s\n' "$cursor_section" | grep -Fq -- "$needle" || fail_with "README.md Cursor Agent CLI section is missing: $needle"; done
+for needle in '/add-plugin' '# uninstall'; do printf '%s\n' "$cursor_section" | grep -Fq -- "$needle" && fail_with "README.md Cursor Agent CLI section must not contain: $needle" || true; done
 
 # Plan template's acceptance header: the four named columns must all be present.
 plan_template="$root/skills/delivery/templates/plan.md"


### PR DESCRIPTION
`README.md` labelled `cursor-agent plugin marketplace remove dely` as
`# uninstall`. It does not uninstall. Verified on cursor-agent
2026.08.25-3e8eec8: after running it, a new Cursor session still listed `dely` in
`/plugin` → Installed with both skills. Every other harness section pairs
`# uninstall` with a real uninstall verb, so Cursor's line promised a parity the
CLI does not offer.

## What the section now says

`plugin marketplace remove` removes the marketplace — Cursor's CLI changelog
(2026-07-13) defines it as deleting a user-scoped marketplace. Uninstalling is
interactive: `/plugin` → `Installed` → select → `Uninstall`, with the caveat that
the action appears only for plugins Cursor manages; a copy installed through
Claude Code shows as `(Claude Code)` with only `Try in chat`. There is no
non-interactive install or uninstall command.

## Contract

`tests/contracts.sh` extracts the Cursor section's fenced block and pins, inside
that fence, all four `plugin marketplace` commands and the comment on the
`remove` line — so a half-edit that corrects the prose but leaves `# uninstall`
on the command still fails. The negative loop forbids `/add-plugin` and any
casing or spacing of a `#uninstall` label, matched case-insensitively in line
with its two neighbouring checks. `tests/contracts.sh` stays at 250 lines against
its `≤ 250` gate; the new coverage was added to loops that already existed.

## Review

One whole-change review, one remediation, then a replanned task after the scoped
re-review did not accept, and a second scoped re-review that did. Three
instrument weaknesses were found and closed in that sequence: section scope
instead of fence scope, four commands left unpinned, and a case-sensitive label
check that `# Uninstall` walked through.

Recorded, not fixed: the fence extraction concatenates every fenced block in the
section, so a decorative second fence could satisfy a positive needle on behalf
of the real one. A comment stating the false claim as a sentence rather than a
label is out of reach of needles by design — the reviewer's reasoning is in the
decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)