### PR TITLE
chore: bump manifests to 0.16.1 so the trust fix reaches installs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -20,8 +20,8 @@ skill="$root/skills/delivery/SKILL.md"
 claude_version="$(jq -r .version "$claude_manifest" 2>/dev/null)"
 codex_version="$(jq -r .version "$codex_manifest" 2>/dev/null)"
 
-if [ "$claude_version" != "0.16.0" ] || [ "$codex_version" != "0.16.0" ]; then
-  fail_with "manifest versions must both be 0.16.0 (claude=$claude_version codex=$codex_version)"
+if [ "$claude_version" != "0.16.1" ] || [ "$codex_version" != "0.16.1" ]; then
+  fail_with "manifest versions must both be 0.16.1 (claude=$claude_version codex=$codex_version)"
 fi
 
 root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"


### PR DESCRIPTION
## Problem

#32 changed the worker launch argv recorded in `skills/delivery/references/harnesses.md` (Cursor becomes `--force --trust`, and `Trust handling` is filled on all six rows), but left both manifests at `0.16.0`.

Plugin caches are keyed by version — each release has its own directory:

```
~/.claude/plugins/cache/dely/dely/0.14.1
~/.claude/plugins/cache/dely/dely/0.16.0   ← holds the pre-#32 copy
```

Observed on the installed `0.16.0` copy after #32 merged:

```
| Cursor Agent CLI | `--force` | ... do not use `-w`/`--worktree`. | |
```

Empty `Trust handling`, no `--trust`. The merged record cannot reach an install that already has a `0.16.0` directory.

## Change

Three lines that must move together, or `contracts.sh` fails:

- `.claude-plugin/plugin.json` → `0.16.1`
- `.codex-plugin/plugin.json` → `0.16.1`
- `tests/contracts.sh:23-24` version pin → `0.16.1`

`.cursor-plugin/plugin.json` keeps no version field; `contracts.sh:78` gates that.

## Verification

The pin discriminates — observed red before green. Leaving the codex manifest at `0.16.0` while the pin expects `0.16.1`:

```
FAIL: manifest versions must both be 0.16.1 (claude=0.16.1 codex=0.16.0)
```

With all three in step: `bash tests/contracts.sh` → `CONTRACTS:0`.

All `AGENTS.md` closure gates green; `tests/contracts.sh` still exactly 250 lines, within its `<= 250` budget.

## Note

Version choice is `0.16.1` rather than a minor bump: this ships no new behaviour of its own, it only makes #32 installable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcGUPsRego8zc7UdCitspo