### PR TITLE
Cut 0.17.1 so the released version matches the merged protocol

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -152,6 +152,14 @@ decision nine fixes with one sentence. Deferred rather than adopted.
 
 #### Consequences
 
+This decision ships in **0.17.1**. `0.17.0` was not reusable: that number had
+already been tagged and released on 2026-09-01 for the tree that added the
+seventh harness, and this record's own change merged three days later. Bumping
+the manifests without advancing the number left two contents sharing one
+version, and an install of `0.17.0` from the release surface returned the
+protocol this decision replaced. A decision that changes the shipped protocol
+names the version that carries it, in this section, before the tag is cut.
+
 Dely's dependence on Orca deepens from launching terminals to owning the worker
 lifecycle. The orchestration guide documents its own contract migrations, so the
 mitigation is the practice this skill already follows: reference the version-

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -20,8 +20,8 @@ skill="$root/skills/delivery/SKILL.md"
 claude_version="$(jq -r .version "$claude_manifest" 2>/dev/null)"
 codex_version="$(jq -r .version "$codex_manifest" 2>/dev/null)"
 
-if [ "$claude_version" != "0.17.0" ] || [ "$codex_version" != "0.17.0" ]; then
-  fail_with "manifest versions must both be 0.17.0 (claude=$claude_version codex=$codex_version)"
+if [ "$claude_version" != "0.17.1" ] || [ "$codex_version" != "0.17.1" ]; then
+  fail_with "manifest versions must both be 0.17.1 (claude=$claude_version codex=$codex_version)"
 fi
 
 root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"


### PR DESCRIPTION
## Why

`v0.17.0` was tagged and released on 2026-09-01 against `c2fc1a9`, the tree that
added the seventh harness. The orchestration execution plane merged three days
later as `af2a439`, and its manifests still read `0.17.0`. Two different trees
carried one number, and installing "0.17.0" from the release surface returned
the protocol that work replaced — observed on this machine, where a plugin cache
directory named `0.17.0` held the old `SKILL.md`.

Rather than move a published tag other clients may already have fetched, this
cuts a new number for the merged content and leaves `v0.17.0` meaning what it
published. The `v0.17.0` release notes now carry that warning.

## What changes

- `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`: `0.17.0` → `0.17.1`
- `tests/contracts.sh`: the version pin and its failure message
- `docs/decisions.md`: the 2026-09-04 entry now names the version that carries
  the decision, why `0.17.0` was not reusable, and a forward rule — a decision
  that changes the shipped protocol names its version before the tag is cut.
  That silence was the root cause, and the review would not close without it.

## Instrument

No new check was needed. `tests/contracts.sh` already compares **both** manifests
against the pinned string, so it is red for each way this can go wrong: either
manifest left behind, or the pin left behind. All four mismatch fixtures were
built and observed red against a green baseline, in an isolated copy.

**Limit:** the gate proves the three places agree, not that `0.17.1` is the right
number — a consistent bump to any value would also pass. That judgement was made
from the repository's own release history, where minor has meant a new capability
or shipped surface and patch has meant a self-correcting protocol change touching
`SKILL.md` and `contracts.sh`.

Context: https://github.com/hieuphung97/dely/issues/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Do4bCKiz2En24e7qeupcCp