### PR TITLE
Cut 0.17.2 and bind the version rule where a delivery reads it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -13,16 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: shipped protocol text requires a version bump
-        if: github.event_name == 'pull_request'
-        run: |
-          base="${{ github.event.pull_request.base.sha }}"
-          if ! git diff --quiet "$base"...HEAD -- skills/; then
-            git diff --quiet "$base"...HEAD -- .claude-plugin/plugin.json .codex-plugin/plugin.json \
-              && { echo "skills/ changed without a manifest version bump"; exit 1; }
-          fi
       - run: git diff --check
       - run: bash -n tests/contracts.sh
       - run: jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json >/dev/null

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -13,6 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: shipped protocol text requires a version bump
+        if: github.event_name == 'pull_request'
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          if ! git diff --quiet "$base"...HEAD -- skills/; then
+            git diff --quiet "$base"...HEAD -- .claude-plugin/plugin.json .codex-plugin/plugin.json \
+              && { echo "skills/ changed without a manifest version bump"; exit 1; }
+          fi
       - run: git diff --check
       - run: bash -n tests/contracts.sh
       - run: jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json >/dev/null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ Repository artifacts are written in English.
   Candidate changes in this checkout take effect for the next delivery, not
   the one shipping them. Plugin caches and any live worker hook wiring are
   refreshed only between plans.
+- A delivery that changes anything under `skills/` advances the version in
+  both plugin manifests and the pin in `tests/contracts.sh`, within that
+  same delivery.
 
 ## Phase dispatch
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -163,8 +163,13 @@ already been tagged and released on 2026-09-01 for the tree that added the
 seventh harness, and this record's own change merged three days later. Bumping
 the manifests without advancing the number left two contents sharing one
 version, and an install of `0.17.0` from the release surface returned the
-protocol this decision replaced. A decision that changes the shipped protocol
-names the version that carries it, in this section, before the tag is cut.
+protocol this decision replaced. A delivery that alters shipped protocol text
+advances the version within that same delivery — whether it authors a decision
+record, amends an existing one, or touches no record at all. The earlier
+wording bound only the author of a new decision, who would name the version
+in this section; pull request #42 amended existing records, so there was no
+section to fill and the manifests stayed at 0.17.1 while the protocol changed.
+**0.17.2** carries that dispatch-claim correction and this rule.
 
 Dely's dependence on Orca deepens from launching terminals to owning the worker
 lifecycle. The orchestration guide documents its own contract migrations, so the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3,7 +3,7 @@
 What has been settled, what is still open, and what was rejected and why.
 Rationale is kept because the reasons are the reusable part.
 
-Last updated 2026-09-04.
+Last updated 2026-09-05.
 
 ---
 
@@ -163,13 +163,21 @@ already been tagged and released on 2026-09-01 for the tree that added the
 seventh harness, and this record's own change merged three days later. Bumping
 the manifests without advancing the number left two contents sharing one
 version, and an install of `0.17.0` from the release surface returned the
-protocol this decision replaced. A delivery that alters shipped protocol text
-advances the version within that same delivery — whether it authors a decision
-record, amends an existing one, or touches no record at all. The earlier
-wording bound only the author of a new decision, who would name the version
-in this section; pull request #42 amended existing records, so there was no
-section to fill and the manifests stayed at 0.17.1 while the protocol changed.
-**0.17.2** carries that dispatch-claim correction and this rule.
+protocol this decision replaced. A delivery that changes anything under
+`skills/` advances the version within that same delivery — whether it authors
+a decision record, amends an existing one, or touches no record at all. The
+earlier wording bound only the author of a new decision, who would name the
+version in this section; pull request #42 amended existing records, so there
+was no section to fill and the manifests stayed at 0.17.1 while the protocol
+changed. The obligation is stated in `AGENTS.md`, which a delivery actually
+reads. Continuous integration on `pull_request` fails when `skills/` changes
+without a change to both versioned manifests; `tests/contracts.sh` then forces
+the pin to match. That guard fires only on `pull_request`, so a direct push
+to `main` is uncovered; it proves a bump happened, never that the number is
+right, so it would not have caught the `0.17.0` reuse; and it is satisfiable
+by bumping the manifests alone, with the existing pin check forcing the third
+site to follow. **0.17.2** carries that dispatch-claim correction and this
+rule.
 
 Dely's dependence on Orca deepens from launching terminals to owning the worker
 lifecycle. The orchestration guide documents its own contract migrations, so the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -170,14 +170,12 @@ earlier wording bound only the author of a new decision, who would name the
 version in this section; pull request #42 amended existing records, so there
 was no section to fill and the manifests stayed at 0.17.1 while the protocol
 changed. The obligation is stated in `AGENTS.md`, which a delivery actually
-reads. Continuous integration on `pull_request` fails when `skills/` changes
-without a change to both versioned manifests; `tests/contracts.sh` then forces
-the pin to match. That guard fires only on `pull_request`, so a direct push
-to `main` is uncovered; it proves a bump happened, never that the number is
-right, so it would not have caught the `0.17.0` reuse; and it is satisfiable
-by bumping the manifests alone, with the existing pin check forcing the third
-site to follow. **0.17.2** carries that dispatch-claim correction and this
-rule.
+reads. It has no executable guard: `tests/contracts.sh` takes a fixture root
+and so cannot read Git history by design, and the continuous-integration guard
+drafted for this delivery was withdrawn after review found it failed the
+compliant case as well as the violating one. Until that guard lands, the rule
+holds by reading only. **0.17.2** carries that dispatch-claim correction and
+this rule.
 
 Dely's dependence on Orca deepens from launching terminals to owning the worker
 lifecycle. The orchestration guide documents its own contract migrations, so the

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -20,8 +20,8 @@ skill="$root/skills/delivery/SKILL.md"
 claude_version="$(jq -r .version "$claude_manifest" 2>/dev/null)"
 codex_version="$(jq -r .version "$codex_manifest" 2>/dev/null)"
 
-if [ "$claude_version" != "0.17.1" ] || [ "$codex_version" != "0.17.1" ]; then
-  fail_with "manifest versions must both be 0.17.1 (claude=$claude_version codex=$codex_version)"
+if [ "$claude_version" != "0.17.2" ] || [ "$codex_version" != "0.17.2" ]; then
+  fail_with "manifest versions must both be 0.17.2 (claude=$claude_version codex=$codex_version)"
 fi
 
 root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"


### PR DESCRIPTION
`0.17.1` was tagged and released on 2026-09-01. PR #42 then changed shipped
protocol text under `skills/` and merged without advancing the version, so
`0.17.1` named two different contents and an install from the release surface
returned the protocol that PR replaced. That is the same defect `0.17.1` was
itself cut to fix.

## What this does

- Advances `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and the
  pin in `tests/contracts.sh` to **0.17.2**.
- Moves the version obligation into `AGENTS.md`, where a delivery actually
  reads it. It previously lived only inside a superseded decision record's
  prose — PR #42 had that file open and still missed it.
- Widens the rule's trigger from "authors a decision record" to "changes
  anything under `skills/`", which is what PR #42 slipped through.

## What was withdrawn

A CI guard was drafted to make the obligation executable. Review found it
failed the compliant case as well as the violating one: the short-circuited
`&&` list was the `if` body's last command, so a delivery that changed
`skills/` **and** bumped both manifests still exited 1, redding the unique
required `contracts` job on every correct pull request. Its own run proved
nothing, because the commit adding it touched no `skills/`.

Control routed to `REPLAN_OR_SPLIT`. The guard leaves this delivery and
returns as its own change with a fixture that covers the success path. Until
then the rule holds by reading only, and `docs/decisions.md` says so rather
than claiming a guard that is not there.

## Review

Three independent reviews. The first raised the reachability Blocking, closed
by the `AGENTS.md` sentence. The second confirmed that closure and raised the
guard Blocking. The third reproduced every closure gate on exact HEAD and
verified the negative claim — that no version guard remains anywhere in the
tree — and returned ACCEPT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Do4bCKiz2En24e7qeupcCp