### PR TITLE
Make the version obligation executable: a pull_request guard on skills/

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -13,6 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: shipped protocol text requires a version bump
+        if: github.event_name == 'pull_request'
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          if ! git diff --quiet "$base"...HEAD -- skills/ \
+             && git diff --quiet "$base"...HEAD -- .claude-plugin/plugin.json .codex-plugin/plugin.json; then
+            echo "skills/ changed without a manifest version bump"; exit 1
+          fi
       - run: git diff --check
       - run: bash -n tests/contracts.sh
       - run: jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json >/dev/null

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -170,12 +170,16 @@ earlier wording bound only the author of a new decision, who would name the
 version in this section; pull request #42 amended existing records, so there
 was no section to fill and the manifests stayed at 0.17.1 while the protocol
 changed. The obligation is stated in `AGENTS.md`, which a delivery actually
-reads. It has no executable guard: `tests/contracts.sh` takes a fixture root
-and so cannot read Git history by design, and the continuous-integration guard
-drafted for this delivery was withdrawn after review found it failed the
-compliant case as well as the violating one. Until that guard lands, the rule
-holds by reading only. **0.17.2** carries that dispatch-claim correction and
-this rule.
+reads. `tests/contracts.sh` takes a fixture root and so cannot read Git
+history by design, which is why continuous integration has to carry the
+guard. CI on `pull_request` now fails when `skills/` changes without a
+change to both versioned manifests. That step fires only on `pull_request`,
+so a direct push to `main` is uncovered. It proves a bump happened, never
+that the number is right — it would not have caught the `0.17.0` reuse that
+started this whole thread. It is satisfiable by bumping the manifests
+alone; the existing pin in `tests/contracts.sh` is what forces the third
+site to follow. **0.17.2** carries that dispatch-claim correction and this
+rule.
 
 Dely's dependence on Orca deepens from launching terminals to owning the worker
 lifecycle. The orchestration guide documents its own contract migrations, so the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -174,9 +174,9 @@ reads. `tests/contracts.sh` takes a fixture root and so cannot read Git
 history by design, which is why continuous integration has to carry the
 guard. CI on `pull_request` now fails when `skills/` changes without a
 change to both versioned manifests. That step fires only on `pull_request`,
-so a direct push to `main` is uncovered. It proves a bump happened, never
-that the number is right — it would not have caught the `0.17.0` reuse that
-started this whole thread. It is satisfiable by bumping the manifests
+so a direct push to `main` is uncovered. It proves both versioned manifests
+changed, never that the number is right: a manifest edited without advancing
+its `version` satisfies it. It is satisfiable by bumping the manifests
 alone; the existing pin in `tests/contracts.sh` is what forces the third
 site to follow. **0.17.2** carries that dispatch-claim correction and this
 rule.


### PR DESCRIPTION
`AGENTS.md` says a delivery that changes anything under `skills/` advances the
version in both plugin manifests and the pin in `tests/contracts.sh`, in that
same delivery. Until now the rule had no executable guard — `tests/contracts.sh`
takes a fixture root and cannot read Git history by design, so CI has to carry it.

## The guard

A `pull_request`-only step, with `fetch-depth: 0` so the base commit is reachable:

```bash
if ! git diff --quiet "$base"...HEAD -- skills/ \
   && git diff --quiet "$base"...HEAD -- .claude-plugin/plugin.json .codex-plugin/plugin.json; then
  echo "skills/ changed without a manifest version bump"; exit 1
fi
```

## Why the counterexample matters here

A first version of this guard was drafted in #43 and **withdrawn at review**. Its
short-circuited `&&` list was the `if` body's last command, so under `bash -e` a
*compliant* delivery — `skills/` changed AND both manifests bumped — still exited
1, silently, redding the unique required `contracts` job on every correct PR. Its
own CI was green only because the commit adding it touched no `skills/`.

That withdrawn guard is this delivery's counterexample: an implementation that
exists, runs, and returns a correct pass on two of three cases. The instrument is
a git fixture, rebuilt independently by the implementer and by the reviewer in
both the real Actions merge-commit shape and the naive PR-head shape:

| Case | skills/ | manifests | Required | Withdrawn | Repaired |
| --- | --- | --- | --- | --- | --- |
| 1 | changed | unchanged | exit 1 + message | 1 ✅ | 1 ✅ |
| 2 | changed | both bumped | exit 0 | **1, silent** ❌ | 0 ✅ |
| 3 | unchanged | — | exit 0 | 0 ✅ | 0 ✅ |
| 4 | changed | file touched, version unchanged | exit 0 | — | 0 ✅ |

This PR changes nothing under `skills/`, so — like its predecessor — its own CI run
proves nothing about the guarded path. The fixture is the instrument, not this run.

## Recorded limits

`docs/decisions.md` records what the guard does not do: it fires only on
`pull_request`, so a direct push to `main` is uncovered; it compares manifest
*files*, so a manifest edited without advancing its `version` satisfies it
(case 4); and it is satisfiable by bumping the manifests alone, with the pin in
`tests/contracts.sh` forcing the third site to follow.

A first draft of those limits claimed the guard "would not have caught the
`0.17.0` reuse". Review disproved that by running the guard against #39's actual
commit pair — it exits 1 there, and on #42's as well. Commit `5195b90` replaces
the false limit with the real one.

## Not addressed

Three non-blocking findings are recorded and deliberately not absorbed: the guard
fails open if `base.sha` is unreachable; re-running a stale `pull_request` event
widens `base...HEAD` and can produce a false negative; and `tests/contracts.sh`
permits the guard step to be deleted without turning red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Do4bCKiz2En24e7qeupcCp