### PR TITLE
The reviewer fetches dispatch evidence, and the counterexample is bound to it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -27,7 +27,7 @@ jobs:
       - run: bash -n tests/contracts.sh
       - run: jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json >/dev/null
       - run: bash tests/contracts.sh
-      - run: test "$(wc -l < tests/contracts.sh)" -le 250
+      - run: test "$(wc -l < tests/contracts.sh)" -le 280
       - run: |
           test ! -e git-hooks/pre-push
           test ! -e docs/delivery-log.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ bash tests/contracts.sh
 ```
 
 ```bash
-test "$(wc -l < tests/contracts.sh)" -le 250
+test "$(wc -l < tests/contracts.sh)" -le 280
 ```
 
 ```bash

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -9,6 +9,98 @@ Last updated 2026-09-05.
 
 ## Settled
 
+### 2026-09-05 — The reviewer reads the implementer's dispatch record, and the contract-script ceiling is 280
+
+#### Context
+
+Probe round 7 ran a full Bounded delivery. The implementer did not observe its
+counterexample; it used the instrument's failure against an absent feature as
+the baseline — exactly what the implementation rule says does not count.
+Control did not catch it. The reviewer did not catch it and returned ACCEPT.
+
+None of the three broke a rule outright. The rules did not join up. The
+counterexample obligation sat on the implementer, as prose in a handoff field
+nothing can check. Review "gets ... the dispatch evidence" — passive. Control
+handed the reviewer a three-line brief with no dispatch evidence in it, and
+the reviewer had no instruction to go and get any. "Reproduce, do not accept"
+named the gates. The reviewer ran the gates. Nothing said to reproduce the
+counterexample.
+
+`tests/contracts.sh` was at exactly 250 lines, with a hard `≤ 250` gate in
+`AGENTS.md` and in `.github/workflows/contracts.yml`. The ceiling exists to
+stop that script growing into a test suite.
+
+#### Decision
+
+The reviewer reads the implementer's dispatch record itself. Review no longer
+describes dispatch evidence as something handed over. The capability is
+`worker-read`: the hook-reported transcript when Orca can prove the worker
+session, otherwise bounded terminal output with a typed `fallbackReason`. The
+skill names that capability; it does not pin argv.
+
+A disposition is not reachable until the reviewer has located, in the
+implementer's dispatch record, the run where the counterexample was observed
+red — an implementation that is present, runs, returns a pass, and is wrong.
+An instrument red because the behaviour was absent is not that run. Where
+Orca cannot recover the record, the reviewer says so with the reason the
+plane gave, and treats the implementer's own account as the thing under
+check rather than as the check.
+
+`tests/contracts.sh` pins that Review prose verbatim. The ceiling rises from
+250 to 280 so the pin can exist. The raise is deliberate room for a pin the
+contract needs; it is not permission to grow the script into a test suite.
+The new budget is not spent beyond the pin.
+
+The pin prevents the sentence from being silently weakened later. It cannot
+make a future reviewer actually look. No instrument available in this
+repository can observe that.
+
+The coupled version is **0.17.3**.
+
+#### Alternatives considered
+
+**Keep review as a recipient of dispatch evidence Control attaches to the
+brief.** Rejected: round 7 already showed Control omitting it, and a
+recipient with nothing in the brief has no rule that tells them to fetch.
+
+**Pin a keyword `grep` for `dispatch record` or `worker-read`.** Rejected:
+that is the counterexample. A weakened "should read the dispatch record"
+keeps the keywords, runs, and passes.
+
+**Raise the ceiling only as far as the pin needs, to 260 or similar.**
+Rejected: a one-off exact fit recreates the bind that forced this raise, and
+the 280 figure is the approved room, not a target to fill.
+
+**Leave the ceiling at 250 and drop a different check to make room.**
+Rejected: the pin is the contract this delivery needs; deleting another
+check to avoid a decided raise would spend the wrong budget.
+
+#### Consequences
+
+Review independence now includes fetching evidence, not only refusing the
+implementer's reasoning. A review that stops at green gates is incomplete
+when the counterexample run is missing from the dispatch record.
+
+The verbatim pin will turn red on a semantics-preserving rewrap of the
+Review section, the same way the maintenance-log pin does. That is accepted.
+
+A later reader should not judge this pin against reviewer behaviour. The
+gap is named, not solved.
+
+#### Non-goals
+
+No new evidence mechanism. No argv for `worker-read`. No checklist, numbered
+procedure, or extra Review subsection. No change to the CI version guard,
+which this delivery is the first to exercise on its guarded path. No
+instrument that observes whether a reviewer looked.
+
+#### Deferred
+
+A further ceiling raise. Trigger: a pin the contract needs that does not fit
+in the remaining budget, with the same reason — room for a pin, not growth
+into a test suite. An eighth harness is one possible such pin, not a
+pre-committed reason to raise.
+
 ### 2026-09-04 — Orca orchestration is the execution plane, and Dely stops hand-rolling dispatch
 
 #### Context
@@ -253,8 +345,9 @@ that Control itself runs on.
 - Requiring the implementer to re-run the scope command before implementing.
   Trigger: drift-cause sentences still naming late scope discovery after roughly
   ten further deliveries.
-- Raising the contract script's line ceiling. Trigger: an eighth harness, whose
-  README and discovery assertions do not fit the remaining budget.
+- Raising the contract script's line ceiling. Settled 2026-09-05 at 280 for a
+  verbatim review pin, not for an eighth harness. A further raise is deferred
+  from that later record.
 - Flipping the Kiro launch prescription away from its interactive flag. Trigger:
   a second machine or a second version reproducing the stall.
 - Handling a first-run vendor modal beyond reading the terminal. Trigger: a

--- a/skills/delivery/SKILL.md
+++ b/skills/delivery/SKILL.md
@@ -261,8 +261,11 @@ thing under check rather than as the check, and say so.
 
 Review independence is role independence: a fresh session that did not
 implement and does not edit the candidate. It gets the decision record (or
-Bounded design), the baseline, the diff, and the dispatch evidence — not the
-implementer's reasoning. The phase adds no sandbox by default; `AGENTS.md` may
+Bounded design), the baseline, and the diff. The reviewer reads the
+implementer's dispatch record itself — not the implementer's reasoning.
+`worker-read` returns the hook-reported transcript when Orca can prove the
+worker session, and otherwise returns bounded terminal output with a typed
+`fallbackReason`. The phase adds no sandbox by default; `AGENTS.md` may
 pin one for a concrete risk.
 
 Review depth is adaptive: Bounded work gets one independent whole-change
@@ -280,6 +283,14 @@ like this one's result.
 
 **Reproduce, do not accept.** Run the gates yourself. A claim you did not
 reproduce is not evidence.
+
+A disposition is not reachable until the reviewer has located, in the
+implementer's dispatch record, the run where the counterexample was
+observed red — an implementation that is present, runs, returns a pass,
+and is wrong. An instrument red because the behaviour was absent is not
+that run. Where Orca cannot recover the record, the reviewer says so with
+the reason the plane gave, and treats the implementer's own account as
+the thing under check rather than as the check.
 
 Classify findings: **Blocking** — contract failure, regression, data or
 security risk. **Important** — missing required behaviour, test, or

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -20,8 +20,8 @@ skill="$root/skills/delivery/SKILL.md"
 claude_version="$(jq -r .version "$claude_manifest" 2>/dev/null)"
 codex_version="$(jq -r .version "$codex_manifest" 2>/dev/null)"
 
-if [ "$claude_version" != "0.17.2" ] || [ "$codex_version" != "0.17.2" ]; then
-  fail_with "manifest versions must both be 0.17.2 (claude=$claude_version codex=$codex_version)"
+if [ "$claude_version" != "0.17.3" ] || [ "$codex_version" != "0.17.3" ]; then
+  fail_with "manifest versions must both be 0.17.3 (claude=$claude_version codex=$codex_version)"
 fi
 
 root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"
@@ -61,6 +61,16 @@ grep -Fq 'worker-start' "$skill" && grep -Fq 'worker_done' "$skill" && grep -Fq 
 grep -Fq 'do not infer it from reading' "$skill" && ! grep -Fq 'proves readiness' "$skill" && grep -Fq 'does not establish that the worker can serve' "$skill" && ! grep -Fq 'that receipt is the evidence' "$root/docs/decisions.md" && grep -Fq 'now rests on the launch argv' "$root/docs/decisions.md" || fail_with "$skill still treats the worker-start receipt as readiness, or $root/docs/decisions.md still cites that receipt as evidence"
 review="$(awk '/^## Review[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$skill")"; [ -n "$review" ] || fail_with "$skill is missing a ## Review section"
 printf '%s\n' "$review" | grep -Fq 'shared mutable state' && printf '%s\n' "$review" | grep -Fq 'did not verify' && printf '%s\n' "$review" | grep -Fq 'not implementing the candidate' && printf '%s\n' "$review" | grep -Fq 'per finding, not per review' || fail_with "$skill ## Review does not carry the sequencing, unverified, Control-owned-amendment, and one-pass-per-finding rules"
+
+# Reviewer dispatch-record obligation is matched verbatim so a weakened 'should' or a dropped locator fails.
+expected_review_section='Review independence is role independence: a fresh session that did not implement and does not edit the candidate. It gets the decision record (or Bounded design), the baseline, and the diff. The reviewer reads the implementer'"'"'s dispatch record itself — not the implementer'"'"'s reasoning. `worker-read` returns the hook-reported transcript when Orca can prove the worker session, and otherwise returns bounded terminal output with a typed `fallbackReason`. The phase adds no sandbox by default; `AGENTS.md` may pin one for a concrete risk. Review depth is adaptive: Bounded work gets one independent whole-change review. Each Architectural task gets an independent task review. After all tasks are accepted, a different fresh reviewer performs one integration review of task interactions, complete-contract coverage, deferred findings, candidate identity, and release readiness. Only that final review is release-binding for Architectural work; Bounded work has no earlier task review and no duplicate integration review. No worker runs while a review of the same working tree runs. The working tree and its gate surface are shared mutable state, and a review reproduces gates in that tree, so a concurrent edit makes another task'"'"'s work look like this one'"'"'s result. **Reproduce, do not accept.** Run the gates yourself. A claim you did not reproduce is not evidence. A disposition is not reachable until the reviewer has located, in the implementer'"'"'s dispatch record, the run where the counterexample was observed red — an implementation that is present, runs, returns a pass, and is wrong. An instrument red because the behaviour was absent is not that run. Where Orca cannot recover the record, the reviewer says so with the reason the plane gave, and treats the implementer'"'"'s own account as the thing under check rather than as the check. Classify findings: **Blocking** — contract failure, regression, data or security risk. **Important** — missing required behaviour, test, or reconciliation. **Minor** — useful, does not block. **Out of scope** — recorded, not absorbed. Return exactly one role disposition: `ACCEPT`, `CHANGES_REQUESTED`, or `BLOCKED`. State what the review did not verify — what it did not reproduce or read. A contradiction you cannot resolve is `CHANGES_REQUESTED`. Do not open remediation over wording when deterministic checks already prove the contract.'
+
+actual_review_section="$(awk '/^## Review$/{flag=1; next} flag && /^#/{exit} flag' "$skill" | tr '\n' ' ' | tr -s ' ')"
+actual_review_section="${actual_review_section# }"
+actual_review_section="${actual_review_section% }"
+
+[ "$actual_review_section" = "$expected_review_section" ] || fail_with "review section in $skill no longer matches the approved reviewer-reads-dispatch-record and counterexample-reproduction contract verbatim"
+
 for f in '--permission-mode bypassPermissions' '--dangerously-skip-permissions' '--trust-all-tools' '--force' 'claude -p' 'codex exec' 'grok --prompt-file' 'agy -p' 'kiro-cli chat --no-interactive' 'cursor-agent -p' 'copilot -p' '--allow-all'; do
   grep -Fq -- "$f" "$harnesses" || fail_with "$harnesses does not name: $f"
   grep -Fq -- "$f" "$root/AGENTS.md" && fail_with "AGENTS.md must not name: $f"
@@ -224,7 +234,7 @@ if jobs.is_a?(Hash) && jobs.keys == ["contracts"]
   required = [
     'git diff --check', 'bash -n tests/contracts.sh',
     'jq -e . plugin.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json .cursor-plugin/plugin.json >/dev/null',
-    'bash tests/contracts.sh', 'test "$(wc -l < tests/contracts.sh)" -le 250',
+    'bash tests/contracts.sh', 'test "$(wc -l < tests/contracts.sh)" -le 280',
     'test ! -e git-hooks/pre-push', 'test ! -e docs/delivery-log.md', 'test ! -e docs/findings.md',
     'test ! -e docs/harness-surface.md', 'test ! -e docs/options.md',
     'test ! -e docs/_plans/2026-08-24-automation-first-dely-design.md',


### PR DESCRIPTION
Probe round 7 ran a full Bounded delivery across three harnesses. The implementer
used the instrument's failure against an **absent** feature as its baseline —
which `SKILL.md` says in as many words does not count — and neither Control nor
the reviewer caught it. The reviewer returned ACCEPT.

Reading the contract afterwards, none of the three broke a rule. The rules did not
join up:

- The whole obligation sat on the implementer, as prose in a handoff field nothing
  can check.
- Review "got" the dispatch evidence — passive. Control handed the reviewer a
  three-line brief containing none, and nothing told the reviewer to go and get any.
- "Reproduce, do not accept. Run the gates yourself." is scoped to **gates**. The
  reviewer did run the gates.

## What changes

Two edits to `skills/delivery/SKILL.md`.

The reviewer now reads the implementer's dispatch record itself rather than being
handed a summary of it. Orca already serves this — `worker-read` returns the
hook-reported transcript when it can prove the worker session, and otherwise
bounded terminal output with a typed `fallbackReason`. No new mechanism, and the
capability is named rather than the argv pinned.

And a disposition is not reachable until the reviewer has located, in that record,
the run where the counterexample was observed red. An instrument red because the
behaviour was absent is not that run. Where Orca cannot recover the record, the
reviewer says so with the reason the plane gave, and the counterexample rests on
the implementer's account rather than on evidence — mirroring the rule already at
the end of `### Handoff`.

## The counterexample

The new text is pinned verbatim in `tests/contracts.sh`, on the pattern already
used for the maintenance-log section.

The counterexample is a **weakened variant of the sentence itself** — "should read
the dispatch record" — which keeps every distinctive keyword. It exists, runs, and
passes plausible `grep -Fq` checks; the verbatim pin rejects it. The reviewer
built its own variant independently and added a second case: deleting the entire
paragraph *also* passes the keyword greps. So absence is provably not the
discriminator, and the pin is.

## Ceiling

`tests/contracts.sh` was at exactly 250/250. The cap rises to **280** to make room
for the pin; the script is now 260 lines and the rest of the budget is unspent.
The ceiling exists to stop this script becoming a test suite, and raising it
deliberately keeps that intent.

## Recorded, not fixed

The ceiling has three copies, and their coupling is one-directional:

- `AGENTS.md` = 250 with the workflow at 280 -> `tests/contracts.sh` exits **0**
- `AGENTS.md` = 280 with the workflow at 250 -> exits **1**

because the required command list is hardcoded at `tests/contracts.sh:235-246`
rather than read from `AGENTS.md`. The human-readable contract is the unchecked
copy. This predates the commit; it is the first delivery to move the value and so
the first to expose it. Classified Out of scope — recorded, not absorbed. CI stays
binding in both drift directions.

Two Minor findings are recorded in the review: a now-subsumed keyword grep at
`contracts.sh:63`, and singular/plural imprecision on the counterexample run.

## What the pin does not do

It stops the sentence being silently weakened later. It cannot make a future
reviewer look. No instrument available in this repository can observe that, and
`docs/decisions.md` says so rather than implying otherwise.

## Version

`0.17.3` in all three coupled sites. This is the first delivery to touch `skills/`
since the CI version guard landed in #44, so it is the first real exercise of that
guard's guarded path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFPwA3GEzovwEoeohLLPjM