### PR TITLE
The dispatch prompt carries the acceptance row as written

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dely",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "description": "An automation-first, Orca-supervised delivery protocol for coding agents.",
   "license": "MIT",
   "keywords": ["delivery", "workflow", "review", "orca", "automation"],

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -15,8 +15,10 @@ Last updated 2026-09-06.
 
 Probe 5 repeated the controlled round under `0.17.7`, which forbids the prompt
 from defining role dispositions. On the measured variable it worked: where the
-previous round's prompt said "if the instrument passes, return ACCEPT", this one
-said only "return exactly one role disposition", echoing this skill's own phrasing.
+previous round's prompt said "If the implementation meets the requirement and the
+instrument passes, return role disposition ACCEPT", this one said only "Return
+exactly one role disposition: ACCEPT or CHANGES_REQUESTED", echoing this skill's
+own phrasing.
 One observation, one harness, a nondeterministic model — a signal, not a proof.
 
 With that defect closed, a second became visible. Control relayed the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -9,6 +9,58 @@ Last updated 2026-09-06.
 
 ## Settled
 
+### 2026-09-06 — The dispatch prompt carries the acceptance row as written
+
+#### Context
+
+Probe 5 repeated the controlled round under `0.17.7`, which forbids the prompt
+from defining role dispositions. On the measured variable it worked: where the
+previous round's prompt said "if the instrument passes, return ACCEPT", this one
+said only "return exactly one role disposition", echoing this skill's own phrasing.
+One observation, one harness, a nondeterministic model — a signal, not a proof.
+
+With that defect closed, a second became visible. Control relayed the
+counterexample and corrupted it. The source required the *instrument* to reject an
+**implementation** emitting an unpadded value; Control wrote that the **script**
+must reject that value as **input**. The implementer then reasoned about its code
+rather than observing anything, and the reviewer tested the corrupted form — a
+property of shell arithmetic rather than of the candidate — and accepted.
+
+The failure mode had moved from omission to corruption. Only separating the two
+made the second visible; while Control could override the contract outright, that
+masked what it did to the evidence it passed on.
+
+This is specific to Bounded work. An implementer reads the decision record, the
+plan and the baseline, so for Architectural work the acceptance table is a file the
+worker reads and Control relays nothing. A Bounded design is approved in chat, so
+the row is real but not durable, and must pass through Control's prose.
+
+#### Decision
+
+Where the design contract states an acceptance row — its instrument, its
+counterexample, and what was observed — the prompt carries that row as written
+rather than a restatement of it. The contract check binds the sentence inside
+`### Launching a worker`, as it already does for the disposition rule.
+
+#### Consequences
+
+`0.17.7` and this change share a failure boundary — Control altering
+protocol-owned meaning while restating it into a prompt — and take different
+remedies: one forbids the prompt from defining what it does not own, the other
+requires verbatim carriage of what it must transmit.
+
+The rule binds because `### Acceptance` is unscoped: a Bounded change alters where
+the design contract is stored, not whether it has an acceptance shape. A Bounded
+design that is prose with no row is already non-conforming rather than a case this
+rule silently declines to cover.
+
+Nothing here observes Control writing a prompt. As with `0.17.7`, only a further
+probe tests this, and one probe is one observation.
+
+This decision ships in **0.17.8**.
+
+---
+
 ### 2026-09-06 — The dispatch prompt states the task, not the disposition criteria
 
 #### Context

--- a/skills/delivery/SKILL.md
+++ b/skills/delivery/SKILL.md
@@ -145,7 +145,10 @@ which this skill already forbids for prompts.
 The dispatch prompt carries the task, its scope and the evidence required.
 It does not define the role dispositions or the conditions for reaching
 one — those belong to this skill, and a prompt that restates them
-narrows or contradicts them.
+narrows or contradicts them. Where the design contract states an
+acceptance row — its instrument, its counterexample, and what was
+observed — the prompt carries that row as written rather than a
+restatement of it.
 
 The `worker-start` receipt records `launch.requested` and `launch.effective`;
 it does not establish that the worker can serve the request or that it

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -20,8 +20,8 @@ skill="$root/skills/delivery/SKILL.md"
 claude_version="$(jq -r .version "$claude_manifest" 2>/dev/null)"
 codex_version="$(jq -r .version "$codex_manifest" 2>/dev/null)"
 
-if [ "$claude_version" != "0.17.7" ] || [ "$codex_version" != "0.17.7" ]; then
-  fail_with "manifest versions must both be 0.17.7 (claude=$claude_version codex=$codex_version)"
+if [ "$claude_version" != "0.17.8" ] || [ "$codex_version" != "0.17.8" ]; then
+  fail_with "manifest versions must both be 0.17.8 (claude=$claude_version codex=$codex_version)"
 fi
 
 root_name="$(jq -r .name "$root_manifest" 2>/dev/null)"
@@ -59,7 +59,7 @@ grep -Fq 'references/harnesses.md' "$skill" && [ -f "$harnesses" ] && ! tr '\n' 
 grep -Fq 'Keep waiting blocking' "$skill" || grep -Fq '`input_accepted` is not submission' "$skill" || grep -Fq 'Allow 90 seconds' "$skill" && fail_with "$skill still carries a hand-rolled readiness or submission procedure"
 grep -Fq 'worker-start' "$skill" && grep -Fq 'worker_done' "$skill" && grep -Fq 'agent_prompt_blocked' "$skill" && grep -Fq 'agent_prompt_stalled' "$skill" && grep -Fq 'payload.reportPath' "$skill" && ! grep -Fq 'is a liveness inspection' "$skill" "$root/docs/decisions.md" && grep -Fq 'retried into that same terminal' "$skill" && grep -Fq 'does not distinguish them' "$root/docs/decisions.md" || fail_with "$skill does not name the orchestration verbs, both typed codes, and a single read-then-retry recovery, or $root/docs/decisions.md still splits recovery across two typed errors"
 grep -Fq 'do not infer it from reading' "$skill" && ! grep -Fq 'proves readiness' "$skill" && grep -Fq 'does not establish that the worker can serve' "$skill" && ! grep -Fq 'that receipt is the evidence' "$root/docs/decisions.md" && grep -Fq 'now rests on the launch argv' "$root/docs/decisions.md" || fail_with "$skill still treats the worker-start receipt as readiness, or $root/docs/decisions.md still cites that receipt as evidence"
-launch="$(awk '/^### Launching a worker$/{flag=1; next} flag && /^#/{exit} flag' "$skill")"; printf '%s\n' "$launch" | grep -Fq 'The dispatch prompt carries the task' && printf '%s\n' "$launch" | grep -Fq 'does not define the role dispositions' || fail_with "$skill does not keep the dispatch prompt from defining the role dispositions"
+launch="$(awk '/^### Launching a worker$/{flag=1; next} flag && /^#/{exit} flag' "$skill")"; printf '%s\n' "$launch" | grep -Fq 'The dispatch prompt carries the task' && printf '%s\n' "$launch" | grep -Fq 'does not define the role dispositions' && printf '%s\n' "$launch" | grep -Fq 'carries that row as written' || fail_with "$skill does not keep the dispatch prompt from defining the role dispositions, or from restating an acceptance row"
 review="$(awk '/^## Review[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$skill")"; [ -n "$review" ] || fail_with "$skill is missing a ## Review section"
 printf '%s\n' "$review" | grep -Fq 'shared mutable state' && printf '%s\n' "$review" | grep -Fq 'did not verify' && printf '%s\n' "$review" | grep -Fq 'not implementing the candidate' && printf '%s\n' "$review" | grep -Fq 'per finding, not per review' || fail_with "$skill ## Review does not carry the sequencing, unverified, Control-owned-amendment, and one-pass-per-finding rules"
 


### PR DESCRIPTION
Probe 5 confirmed `0.17.7` works on its target. Under `0.17.6` Control wrote into
the reviewer's prompt:

> If the implementation meets the requirement and the instrument passes, return
> role disposition ACCEPT.

Under `0.17.7`, same Control, same brief, same task, it wrote only:

> Return exactly one role disposition: ACCEPT or CHANGES_REQUESTED.

The conditional criterion is gone, and the phrasing is `SKILL.md`'s own — relaying
rather than inventing. One observation, one harness, a nondeterministic model: a
signal, not a proof.

## The defect that became visible once the first stopped masking it

Control relayed the counterexample and **corrupted** it. The source required the
*instrument* to reject an **implementation** emitting an unpadded value. Control
wrote that the **script** must reject that value as **input**. The implementer then
reasoned about its own code rather than observing anything; the reviewer "verified"
by passing the value as an argument and seeing an arithmetic error — a property of
`$(( ))`, not of the candidate — and accepted.

The failure moved from **omission** to **corruption**. It was invisible while
Control could override the contract outright.

## Why this is Bounded-only

An implementer reads the decision record, the plan and the baseline. For
Architectural work the acceptance table is a file the worker reads and Control
relays nothing. A Bounded design is approved in chat, so the row is real but not
durable and must pass through Control's prose.

## What changes

One sentence, extending the paragraph `0.17.7` added: where the design contract
states an acceptance row — its instrument, its counterexample, and what was
observed — the prompt carries that row as written rather than a restatement.

The contract check binds it inside `### Launching a worker`, as it already does for
the disposition rule. Review reproduced that binding: relocating the paragraph
fails the suite.

## The antecedent holds

The obvious weakness was that the sentence is conditioned on a design contract
stating an acceptance row, while Bounded work has no artefact. Review settled it on
the text: `### Acceptance` is unscoped and requires "one table"; `README.md` states
the same unqualified rule. A Bounded change alters where the contract is stored,
not whether it has an acceptance shape. A Bounded design that is prose with no row
is already non-conforming.

## Two corrections during release, both Control's

Review found the decision record had shortened the prior prompt, dropping a
conjunct and sharpening the contrast in Control's favour. That is the third time in
this session that Control compressed something in `docs/decisions.md` and erred in
the direction that strengthened its own argument; all three were caught by checking
the record against the source rather than against Control's summary. The
quotations are now given in full, verified by the reviewer against the stored
orchestration task specs rather than against the brief.

The review pin also changed mid-delivery. The first reviewer was stopped 2.5
minutes in, before any heartbeat, and the task was retried onto the new pin. No
verdict from the stopped worker was used.

## What this does not do

Nothing here observes Control writing a prompt. Only a further probe tests it, and
one probe is one observation. The decision record says so.

## Version

`0.17.8` in all three coupled sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFPwA3GEzovwEoeohLLPjM