### PR TITLE
Pin review to Codex CLI gpt-5.6-sol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ delivery run.
 | Phase | Harness | Model | Effort |
 | --- | --- | --- | --- |
 | `implement` | Cursor Agent CLI | cursor-grok-4.6-high | default |
-| `review` | Claude Code | opus | high |
+| `review` | Codex CLI | gpt-5.6-sol | high |
 <!-- dely:end -->
 
 The table is this repository's deployment selection, not the portable


### PR DESCRIPTION
One line in the managed block: the `review` phase moves from Claude Code `opus`
`high` to Codex CLI `gpt-5.6-sol` `high`.

This is the repository's deployment selection, which `AGENTS.md` itself says is
"not the portable protocol". Nothing under `skills/` changes, so no version
advances and the CI version guard's guarded path evaluates to exit 0.

No review was dispatched. The managed block records which harness and model the
maintainer wants for a phase; that is a choice, not a claim a reviewer could
reproduce or refute. `tests/contracts.sh` checks the structural contract and runs
in CI here.

The pin was already in effect for the last two reviews of #51 — the first reviewer
under the old pin was stopped 2.5 minutes in, before any heartbeat, and the task
was retried onto this one. Until now it existed only in the maintainer's working
tree, so a clone still saw the old pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtEVXwfu8988GoD7qJB4Gq