### PR TITLE
Play the Dely demo inline on the GitHub README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 Ask for a change; Dely takes it through design approval, implementation,
 independent review, and a pull request you merge.
 
-[![Dely demo](https://img.youtube.com/vi/6pRWkhlQSAc/maxresdefault.jpg)](https://www.youtube.com/watch?v=6pRWkhlQSAc)
+https://github.com/user-attachments/assets/83ec539a-6551-4807-8517-0c73e5d171d7
+
+[YouTube](https://www.youtube.com/watch?v=6pRWkhlQSAc)
 
 ## Contents
 

--- a/tests/contracts.sh
+++ b/tests/contracts.sh
@@ -168,7 +168,9 @@ for needle in 'plugin marketplace add' 'plugin install dely@dely' 'plugin list' 
 quickstart="$(awk '/^## Quickstart[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$root/README.md")"
 [ -n "$quickstart" ] || fail_with "README.md is missing a ## Quickstart section"
 printf '%s\n' "$quickstart" | grep -Fq 'orca orchestration run-list --json' || fail_with "README.md Quickstart does not give orca orchestration run-list --json as the confirmation command"
-awk '/6pRWkhlQSAc/{v=NR} /^## Quickstart[[:space:]]*$/{q=NR} END{exit (v&&q&&v<q)?0:1}' "$root/README.md" || fail_with "README.md YouTube id 6pRWkhlQSAc is missing or not before ## Quickstart"
+awk '/https:\/\/github.com\/user-attachments\/assets\/83ec539a-6551-4807-8517-0c73e5d171d7/{v=NR} /^## Quickstart[[:space:]]*$/{q=NR} END{exit (v&&q&&v<q)?0:1}' "$root/README.md" || fail_with "README.md GitHub demo asset URL is missing or not before ## Quickstart"
+grep -Fq 'img.youtube.com' "$root/README.md" && fail_with "README.md must not contain img.youtube.com" || true
+grep -Fq 'https://www.youtube.com/watch?v=6pRWkhlQSAc' "$root/README.md" || fail_with "README.md is missing https://www.youtube.com/watch?v=6pRWkhlQSAc"
 contents="$(awk '/^## Contents[[:space:]]*$/{p=1;next} p && /^## /{exit} p' "$root/README.md")"
 [ -n "$contents" ] || fail_with "README.md is missing a ## Contents section"
 for h in '#quickstart' '#project-setup' '#install' '#troubleshooting'; do printf '%s\n' "$contents" | grep -Fq "]($h)" || fail_with "README.md Contents is missing link: $h"; done


### PR DESCRIPTION
## Summary
- Replace the YouTube thumbnail (off-site redirect) with a GitHub-hosted MP4 so the demo plays on the repository page.
- Keep a text link to the YouTube copy.
- Update `tests/contracts.sh` to require the GitHub asset URL before Quickstart and to forbid `img.youtube.com`.

The mp4 is not in git; it is hosted at `https://github.com/user-attachments/assets/83ec539a-6551-4807-8517-0c73e5d171d7`.

## Test plan
- [ ] Open the repo README on GitHub and play the demo without leaving the page
- [ ] Confirm the YouTube text link still works
- [ ] `bash tests/contracts.sh` (also CI `contracts`)


Made with [Cursor](https://cursor.com)